### PR TITLE
Implement minimal Intl module for timezone support with DateTimeFormat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ target
 Cargo.lock
 .DS_Store
 .idea
+vendor
+history.js

--- a/modules/Cargo.toml
+++ b/modules/Cargo.toml
@@ -17,6 +17,11 @@ simd-json = "0.17.0"
 rand = "0.9.2"
 tokio = { version = "1", features = ["full"], optional = true }
 
+# intl
+chrono = { version = "0.4", features = ["std", "clock"], default-features = false, optional = true }
+chrono-tz = { version = "0.10", default-features = false, optional = true }
+iana-time-zone = { version = "0.1", optional = true }
+
 # source
 oxc = { version = "0.105.0", optional = true, features = [
     "transformer",
@@ -78,6 +83,7 @@ default = [
     "http",
     "url",
     "fetch",
+    "intl",
 ]
 
 event = []
@@ -101,6 +107,7 @@ http = [
 ]
 url = []
 fetch = ["http", "percent-encoding", "url"]
+intl = ["chrono", "chrono-tz", "iana-time-zone"]
 
 
 [dev-dependencies]

--- a/modules/src/intl/cldr_data.rs
+++ b/modules/src/intl/cldr_data.rs
@@ -1,0 +1,1674 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Baked CLDR locale data for date/time formatting.
+//!
+//! This module contains pre-extracted patterns from the Unicode CLDR project
+//! for a subset of common locales, enabling locale-aware date/time formatting
+//! without requiring the full ICU library.
+//!
+//! Data sourced from: https://github.com/unicode-org/cldr-json
+
+/// Locale-specific date/time formatting data
+#[derive(Debug, Clone)]
+pub struct LocaleData {
+    /// Date format patterns (full, long, medium, short)
+    pub date_formats: DateFormats,
+    /// Time format patterns (full, long, medium, short)
+    pub time_formats: TimeFormats,
+    /// Pattern for combining date and time (e.g., "{1}, {0}")
+    pub datetime_pattern: &'static str,
+    /// Month names (wide format, 1-indexed internally but stored 0-indexed)
+    pub months_wide: [&'static str; 12],
+    /// Month names (abbreviated format)
+    pub months_abbr: [&'static str; 12],
+    /// Weekday names (wide format, 0=Sunday)
+    pub days_wide: [&'static str; 7],
+    /// Weekday names (abbreviated format)
+    pub days_abbr: [&'static str; 7],
+    /// AM marker
+    pub am: &'static str,
+    /// PM marker
+    pub pm: &'static str,
+    /// Whether this locale uses 12-hour time by default
+    pub hour12_default: bool,
+}
+
+/// Date format patterns for different styles
+#[derive(Debug, Clone)]
+pub struct DateFormats {
+    pub full: &'static str,
+    pub long: &'static str,
+    pub medium: &'static str,
+    pub short: &'static str,
+}
+
+/// Time format patterns for different styles
+#[derive(Debug, Clone)]
+pub struct TimeFormats {
+    pub full: &'static str,
+    pub long: &'static str,
+    pub medium: &'static str,
+    pub short: &'static str,
+}
+
+/// Get locale data for a given locale string.
+/// Falls back to en-US for unknown locales.
+pub fn get_locale_data(locale: &str) -> &'static LocaleData {
+    // Normalize locale: lowercase, handle both - and _
+    let locale_lower = locale.to_lowercase().replace('_', "-");
+
+    // Try exact match first, then language-only fallback
+    match locale_lower.as_str() {
+        "en-us" | "en" => &EN_US,
+        "en-gb" | "en-au" | "en-nz" | "en-ie" => &EN_GB,
+        "de" | "de-de" | "de-at" | "de-ch" => &DE,
+        "fr" | "fr-fr" | "fr-ca" | "fr-be" | "fr-ch" => &FR,
+        "es" | "es-es" | "es-mx" | "es-ar" => &ES,
+        "it" | "it-it" => &IT,
+        "pt" | "pt-pt" | "pt-br" => &PT,
+        "nl" | "nl-nl" | "nl-be" => &NL,
+        "ru" | "ru-ru" => &RU,
+        "ja" | "ja-jp" => &JA,
+        "ko" | "ko-kr" => &KO,
+        "zh" | "zh-cn" | "zh-hans" => &ZH,
+        "zh-tw" | "zh-hant" | "zh-hk" => &ZH_TW,
+        "ar" | "ar-sa" | "ar-eg" => &AR,
+        // High priority locales
+        "hi" | "hi-in" => &HI,
+        "bn" | "bn-bd" | "bn-in" => &BN,
+        "vi" | "vi-vn" => &VI,
+        "th" | "th-th" => &TH,
+        "id" | "id-id" => &ID,
+        "tr" | "tr-tr" => &TR,
+        "pl" | "pl-pl" => &PL,
+        "uk" | "uk-ua" => &UK,
+        // Medium priority locales
+        "sv" | "sv-se" => &SV,
+        "da" | "da-dk" => &DA,
+        "nb" | "nb-no" | "no" | "nn" | "nn-no" => &NB,
+        "fi" | "fi-fi" => &FI,
+        "cs" | "cs-cz" => &CS,
+        "el" | "el-gr" => &EL,
+        "he" | "he-il" | "iw" => &HE,
+        "hu" | "hu-hu" => &HU,
+        "ro" | "ro-ro" => &RO,
+        // Fallback to en-US
+        _ => {
+            // Try to match just the language part
+            if let Some(lang) = locale_lower.split('-').next() {
+                match lang {
+                    "en" => &EN_US,
+                    "de" => &DE,
+                    "fr" => &FR,
+                    "es" => &ES,
+                    "it" => &IT,
+                    "pt" => &PT,
+                    "nl" => &NL,
+                    "ru" => &RU,
+                    "ja" => &JA,
+                    "ko" => &KO,
+                    "zh" => &ZH,
+                    "ar" => &AR,
+                    "hi" => &HI,
+                    "bn" => &BN,
+                    "vi" => &VI,
+                    "th" => &TH,
+                    "id" => &ID,
+                    "tr" => &TR,
+                    "pl" => &PL,
+                    "uk" => &UK,
+                    "sv" => &SV,
+                    "da" => &DA,
+                    "nb" | "no" | "nn" => &NB,
+                    "fi" => &FI,
+                    "cs" => &CS,
+                    "el" => &EL,
+                    "he" | "iw" => &HE,
+                    "hu" => &HU,
+                    "ro" => &RO,
+                    _ => &EN_US,
+                }
+            } else {
+                &EN_US
+            }
+        },
+    }
+}
+
+// English (US) - en-US
+static EN_US: LocaleData = LocaleData {
+    date_formats: DateFormats {
+        full: "EEEE, MMMM d, y",
+        long: "MMMM d, y",
+        medium: "MMM d, y",
+        short: "M/d/yy",
+    },
+    time_formats: TimeFormats {
+        full: "h:mm:ss a zzzz",
+        long: "h:mm:ss a z",
+        medium: "h:mm:ss a",
+        short: "h:mm a",
+    },
+    datetime_pattern: "{1}, {0}",
+    months_wide: [
+        "January",
+        "February",
+        "March",
+        "April",
+        "May",
+        "June",
+        "July",
+        "August",
+        "September",
+        "October",
+        "November",
+        "December",
+    ],
+    months_abbr: [
+        "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+    ],
+    days_wide: [
+        "Sunday",
+        "Monday",
+        "Tuesday",
+        "Wednesday",
+        "Thursday",
+        "Friday",
+        "Saturday",
+    ],
+    days_abbr: ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"],
+    am: "AM",
+    pm: "PM",
+    hour12_default: true,
+};
+
+// English (GB) - en-GB
+static EN_GB: LocaleData = LocaleData {
+    date_formats: DateFormats {
+        full: "EEEE, d MMMM y",
+        long: "d MMMM y",
+        medium: "d MMM y",
+        short: "dd/MM/y",
+    },
+    time_formats: TimeFormats {
+        full: "HH:mm:ss zzzz",
+        long: "HH:mm:ss z",
+        medium: "HH:mm:ss",
+        short: "HH:mm",
+    },
+    datetime_pattern: "{1}, {0}",
+    months_wide: [
+        "January",
+        "February",
+        "March",
+        "April",
+        "May",
+        "June",
+        "July",
+        "August",
+        "September",
+        "October",
+        "November",
+        "December",
+    ],
+    months_abbr: [
+        "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+    ],
+    days_wide: [
+        "Sunday",
+        "Monday",
+        "Tuesday",
+        "Wednesday",
+        "Thursday",
+        "Friday",
+        "Saturday",
+    ],
+    days_abbr: ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"],
+    am: "am",
+    pm: "pm",
+    hour12_default: false,
+};
+
+// German - de
+static DE: LocaleData = LocaleData {
+    date_formats: DateFormats {
+        full: "EEEE, d. MMMM y",
+        long: "d. MMMM y",
+        medium: "dd.MM.y",
+        short: "dd.MM.yy",
+    },
+    time_formats: TimeFormats {
+        full: "HH:mm:ss zzzz",
+        long: "HH:mm:ss z",
+        medium: "HH:mm:ss",
+        short: "HH:mm",
+    },
+    datetime_pattern: "{1}, {0}",
+    months_wide: [
+        "Januar",
+        "Februar",
+        "März",
+        "April",
+        "Mai",
+        "Juni",
+        "Juli",
+        "August",
+        "September",
+        "Oktober",
+        "November",
+        "Dezember",
+    ],
+    months_abbr: [
+        "Jan.", "Feb.", "März", "Apr.", "Mai", "Juni", "Juli", "Aug.", "Sep.", "Okt.", "Nov.",
+        "Dez.",
+    ],
+    days_wide: [
+        "Sonntag",
+        "Montag",
+        "Dienstag",
+        "Mittwoch",
+        "Donnerstag",
+        "Freitag",
+        "Samstag",
+    ],
+    days_abbr: ["So.", "Mo.", "Di.", "Mi.", "Do.", "Fr.", "Sa."],
+    am: "AM",
+    pm: "PM",
+    hour12_default: false,
+};
+
+// French - fr
+static FR: LocaleData = LocaleData {
+    date_formats: DateFormats {
+        full: "EEEE d MMMM y",
+        long: "d MMMM y",
+        medium: "d MMM y",
+        short: "dd/MM/y",
+    },
+    time_formats: TimeFormats {
+        full: "HH:mm:ss zzzz",
+        long: "HH:mm:ss z",
+        medium: "HH:mm:ss",
+        short: "HH:mm",
+    },
+    datetime_pattern: "{1}, {0}",
+    months_wide: [
+        "janvier",
+        "février",
+        "mars",
+        "avril",
+        "mai",
+        "juin",
+        "juillet",
+        "août",
+        "septembre",
+        "octobre",
+        "novembre",
+        "décembre",
+    ],
+    months_abbr: [
+        "janv.", "févr.", "mars", "avr.", "mai", "juin", "juil.", "août", "sept.", "oct.", "nov.",
+        "déc.",
+    ],
+    days_wide: [
+        "dimanche", "lundi", "mardi", "mercredi", "jeudi", "vendredi", "samedi",
+    ],
+    days_abbr: ["dim.", "lun.", "mar.", "mer.", "jeu.", "ven.", "sam."],
+    am: "AM",
+    pm: "PM",
+    hour12_default: false,
+};
+
+// Spanish - es
+static ES: LocaleData = LocaleData {
+    date_formats: DateFormats {
+        full: "EEEE, d 'de' MMMM 'de' y",
+        long: "d 'de' MMMM 'de' y",
+        medium: "d MMM y",
+        short: "d/M/yy",
+    },
+    time_formats: TimeFormats {
+        full: "H:mm:ss zzzz",
+        long: "H:mm:ss z",
+        medium: "H:mm:ss",
+        short: "H:mm",
+    },
+    datetime_pattern: "{1}, {0}",
+    months_wide: [
+        "enero",
+        "febrero",
+        "marzo",
+        "abril",
+        "mayo",
+        "junio",
+        "julio",
+        "agosto",
+        "septiembre",
+        "octubre",
+        "noviembre",
+        "diciembre",
+    ],
+    months_abbr: [
+        "ene", "feb", "mar", "abr", "may", "jun", "jul", "ago", "sept", "oct", "nov", "dic",
+    ],
+    days_wide: [
+        "domingo",
+        "lunes",
+        "martes",
+        "miércoles",
+        "jueves",
+        "viernes",
+        "sábado",
+    ],
+    days_abbr: ["dom", "lun", "mar", "mié", "jue", "vie", "sáb"],
+    am: "a.\u{a0}m.",
+    pm: "p.\u{a0}m.",
+    hour12_default: false,
+};
+
+// Italian - it
+static IT: LocaleData = LocaleData {
+    date_formats: DateFormats {
+        full: "EEEE d MMMM y",
+        long: "d MMMM y",
+        medium: "d MMM y",
+        short: "dd/MM/yy",
+    },
+    time_formats: TimeFormats {
+        full: "HH:mm:ss zzzz",
+        long: "HH:mm:ss z",
+        medium: "HH:mm:ss",
+        short: "HH:mm",
+    },
+    datetime_pattern: "{1}, {0}",
+    months_wide: [
+        "gennaio",
+        "febbraio",
+        "marzo",
+        "aprile",
+        "maggio",
+        "giugno",
+        "luglio",
+        "agosto",
+        "settembre",
+        "ottobre",
+        "novembre",
+        "dicembre",
+    ],
+    months_abbr: [
+        "gen", "feb", "mar", "apr", "mag", "giu", "lug", "ago", "set", "ott", "nov", "dic",
+    ],
+    days_wide: [
+        "domenica",
+        "lunedì",
+        "martedì",
+        "mercoledì",
+        "giovedì",
+        "venerdì",
+        "sabato",
+    ],
+    days_abbr: ["dom", "lun", "mar", "mer", "gio", "ven", "sab"],
+    am: "AM",
+    pm: "PM",
+    hour12_default: false,
+};
+
+// Portuguese - pt
+static PT: LocaleData = LocaleData {
+    date_formats: DateFormats {
+        full: "EEEE, d 'de' MMMM 'de' y",
+        long: "d 'de' MMMM 'de' y",
+        medium: "d 'de' MMM 'de' y",
+        short: "dd/MM/y",
+    },
+    time_formats: TimeFormats {
+        full: "HH:mm:ss zzzz",
+        long: "HH:mm:ss z",
+        medium: "HH:mm:ss",
+        short: "HH:mm",
+    },
+    datetime_pattern: "{1}, {0}",
+    months_wide: [
+        "janeiro",
+        "fevereiro",
+        "março",
+        "abril",
+        "maio",
+        "junho",
+        "julho",
+        "agosto",
+        "setembro",
+        "outubro",
+        "novembro",
+        "dezembro",
+    ],
+    months_abbr: [
+        "jan", "fev", "mar", "abr", "mai", "jun", "jul", "ago", "set", "out", "nov", "dez",
+    ],
+    days_wide: [
+        "domingo",
+        "segunda-feira",
+        "terça-feira",
+        "quarta-feira",
+        "quinta-feira",
+        "sexta-feira",
+        "sábado",
+    ],
+    days_abbr: ["dom", "seg", "ter", "qua", "qui", "sex", "sáb"],
+    am: "AM",
+    pm: "PM",
+    hour12_default: false,
+};
+
+// Dutch - nl
+static NL: LocaleData = LocaleData {
+    date_formats: DateFormats {
+        full: "EEEE d MMMM y",
+        long: "d MMMM y",
+        medium: "d MMM y",
+        short: "dd-MM-y",
+    },
+    time_formats: TimeFormats {
+        full: "HH:mm:ss zzzz",
+        long: "HH:mm:ss z",
+        medium: "HH:mm:ss",
+        short: "HH:mm",
+    },
+    datetime_pattern: "{1}, {0}",
+    months_wide: [
+        "januari",
+        "februari",
+        "maart",
+        "april",
+        "mei",
+        "juni",
+        "juli",
+        "augustus",
+        "september",
+        "oktober",
+        "november",
+        "december",
+    ],
+    months_abbr: [
+        "jan", "feb", "mrt", "apr", "mei", "jun", "jul", "aug", "sep", "okt", "nov", "dec",
+    ],
+    days_wide: [
+        "zondag",
+        "maandag",
+        "dinsdag",
+        "woensdag",
+        "donderdag",
+        "vrijdag",
+        "zaterdag",
+    ],
+    days_abbr: ["zo", "ma", "di", "wo", "do", "vr", "za"],
+    am: "a.m.",
+    pm: "p.m.",
+    hour12_default: false,
+};
+
+// Russian - ru
+static RU: LocaleData = LocaleData {
+    date_formats: DateFormats {
+        full: "EEEE, d MMMM y 'г'.",
+        long: "d MMMM y 'г'.",
+        medium: "d MMM y 'г'.",
+        short: "dd.MM.y",
+    },
+    time_formats: TimeFormats {
+        full: "HH:mm:ss zzzz",
+        long: "HH:mm:ss z",
+        medium: "HH:mm:ss",
+        short: "HH:mm",
+    },
+    datetime_pattern: "{1}, {0}",
+    months_wide: [
+        "января",
+        "февраля",
+        "марта",
+        "апреля",
+        "мая",
+        "июня",
+        "июля",
+        "августа",
+        "сентября",
+        "октября",
+        "ноября",
+        "декабря",
+    ],
+    months_abbr: [
+        "янв.",
+        "февр.",
+        "мар.",
+        "апр.",
+        "мая",
+        "июн.",
+        "июл.",
+        "авг.",
+        "сент.",
+        "окт.",
+        "нояб.",
+        "дек.",
+    ],
+    days_wide: [
+        "воскресенье",
+        "понедельник",
+        "вторник",
+        "среда",
+        "четверг",
+        "пятница",
+        "суббота",
+    ],
+    days_abbr: ["вс", "пн", "вт", "ср", "чт", "пт", "сб"],
+    am: "AM",
+    pm: "PM",
+    hour12_default: false,
+};
+
+// Japanese - ja
+static JA: LocaleData = LocaleData {
+    date_formats: DateFormats {
+        full: "y年M月d日EEEE",
+        long: "y年M月d日",
+        medium: "y/MM/dd",
+        short: "y/MM/dd",
+    },
+    time_formats: TimeFormats {
+        full: "H時mm分ss秒 zzzz",
+        long: "H:mm:ss z",
+        medium: "H:mm:ss",
+        short: "H:mm",
+    },
+    datetime_pattern: "{1} {0}",
+    months_wide: [
+        "1月", "2月", "3月", "4月", "5月", "6月", "7月", "8月", "9月", "10月", "11月", "12月",
+    ],
+    months_abbr: [
+        "1月", "2月", "3月", "4月", "5月", "6月", "7月", "8月", "9月", "10月", "11月", "12月",
+    ],
+    days_wide: [
+        "日曜日",
+        "月曜日",
+        "火曜日",
+        "水曜日",
+        "木曜日",
+        "金曜日",
+        "土曜日",
+    ],
+    days_abbr: ["日", "月", "火", "水", "木", "金", "土"],
+    am: "午前",
+    pm: "午後",
+    hour12_default: false,
+};
+
+// Korean - ko
+static KO: LocaleData = LocaleData {
+    date_formats: DateFormats {
+        full: "y년 MMMM d일 EEEE",
+        long: "y년 MMMM d일",
+        medium: "y. M. d.",
+        short: "yy. M. d.",
+    },
+    time_formats: TimeFormats {
+        full: "a h시 m분 s초 zzzz",
+        long: "a h시 m분 s초 z",
+        medium: "a h:mm:ss",
+        short: "a h:mm",
+    },
+    datetime_pattern: "{1} {0}",
+    months_wide: [
+        "1월", "2월", "3월", "4월", "5월", "6월", "7월", "8월", "9월", "10월", "11월", "12월",
+    ],
+    months_abbr: [
+        "1월", "2월", "3월", "4월", "5월", "6월", "7월", "8월", "9월", "10월", "11월", "12월",
+    ],
+    days_wide: [
+        "일요일",
+        "월요일",
+        "화요일",
+        "수요일",
+        "목요일",
+        "금요일",
+        "토요일",
+    ],
+    days_abbr: ["일", "월", "화", "수", "목", "금", "토"],
+    am: "오전",
+    pm: "오후",
+    hour12_default: true,
+};
+
+// Chinese (Simplified) - zh
+static ZH: LocaleData = LocaleData {
+    date_formats: DateFormats {
+        full: "y年M月d日EEEE",
+        long: "y年M月d日",
+        medium: "y年M月d日",
+        short: "y/M/d",
+    },
+    time_formats: TimeFormats {
+        full: "zzzz HH:mm:ss",
+        long: "z HH:mm:ss",
+        medium: "HH:mm:ss",
+        short: "HH:mm",
+    },
+    datetime_pattern: "{1} {0}",
+    months_wide: [
+        "一月",
+        "二月",
+        "三月",
+        "四月",
+        "五月",
+        "六月",
+        "七月",
+        "八月",
+        "九月",
+        "十月",
+        "十一月",
+        "十二月",
+    ],
+    months_abbr: [
+        "1月", "2月", "3月", "4月", "5月", "6月", "7月", "8月", "9月", "10月", "11月", "12月",
+    ],
+    days_wide: [
+        "星期日",
+        "星期一",
+        "星期二",
+        "星期三",
+        "星期四",
+        "星期五",
+        "星期六",
+    ],
+    days_abbr: ["周日", "周一", "周二", "周三", "周四", "周五", "周六"],
+    am: "上午",
+    pm: "下午",
+    hour12_default: false,
+};
+
+// Chinese (Traditional) - zh-TW
+static ZH_TW: LocaleData = LocaleData {
+    date_formats: DateFormats {
+        full: "y年M月d日 EEEE",
+        long: "y年M月d日",
+        medium: "y年M月d日",
+        short: "y/M/d",
+    },
+    time_formats: TimeFormats {
+        full: "ah:mm:ss [zzzz]",
+        long: "ah:mm:ss [z]",
+        medium: "ah:mm:ss",
+        short: "ah:mm",
+    },
+    datetime_pattern: "{1} {0}",
+    months_wide: [
+        "1月", "2月", "3月", "4月", "5月", "6月", "7月", "8月", "9月", "10月", "11月", "12月",
+    ],
+    months_abbr: [
+        "1月", "2月", "3月", "4月", "5月", "6月", "7月", "8月", "9月", "10月", "11月", "12月",
+    ],
+    days_wide: [
+        "星期日",
+        "星期一",
+        "星期二",
+        "星期三",
+        "星期四",
+        "星期五",
+        "星期六",
+    ],
+    days_abbr: ["週日", "週一", "週二", "週三", "週四", "週五", "週六"],
+    am: "上午",
+    pm: "下午",
+    hour12_default: true,
+};
+
+// Arabic - ar
+static AR: LocaleData = LocaleData {
+    date_formats: DateFormats {
+        full: "EEEE، d MMMM y",
+        long: "d MMMM y",
+        medium: "dd/MM/y",
+        short: "d/M/y",
+    },
+    time_formats: TimeFormats {
+        full: "h:mm:ss a zzzz",
+        long: "h:mm:ss a z",
+        medium: "h:mm:ss a",
+        short: "h:mm a",
+    },
+    datetime_pattern: "{1}, {0}",
+    months_wide: [
+        "يناير",
+        "فبراير",
+        "مارس",
+        "أبريل",
+        "مايو",
+        "يونيو",
+        "يوليو",
+        "أغسطس",
+        "سبتمبر",
+        "أكتوبر",
+        "نوفمبر",
+        "ديسمبر",
+    ],
+    months_abbr: [
+        "يناير",
+        "فبراير",
+        "مارس",
+        "أبريل",
+        "مايو",
+        "يونيو",
+        "يوليو",
+        "أغسطس",
+        "سبتمبر",
+        "أكتوبر",
+        "نوفمبر",
+        "ديسمبر",
+    ],
+    days_wide: [
+        "الأحد",
+        "الاثنين",
+        "الثلاثاء",
+        "الأربعاء",
+        "الخميس",
+        "الجمعة",
+        "السبت",
+    ],
+    days_abbr: [
+        "الأحد",
+        "الاثنين",
+        "الثلاثاء",
+        "الأربعاء",
+        "الخميس",
+        "الجمعة",
+        "السبت",
+    ],
+    am: "ص",
+    pm: "م",
+    hour12_default: true,
+};
+
+// Hindi - hi
+static HI: LocaleData = LocaleData {
+    date_formats: DateFormats {
+        full: "EEEE, d MMMM y",
+        long: "d MMMM y",
+        medium: "d MMM y",
+        short: "d/M/yy",
+    },
+    time_formats: TimeFormats {
+        full: "h:mm:ss a zzzz",
+        long: "h:mm:ss a z",
+        medium: "h:mm:ss a",
+        short: "h:mm a",
+    },
+    datetime_pattern: "{1}, {0}",
+    months_wide: [
+        "जनवरी",
+        "फ़रवरी",
+        "मार्च",
+        "अप्रैल",
+        "मई",
+        "जून",
+        "जुलाई",
+        "अगस्त",
+        "सितंबर",
+        "अक्तूबर",
+        "नवंबर",
+        "दिसंबर",
+    ],
+    months_abbr: [
+        "जन॰",
+        "फ़र॰",
+        "मार्च",
+        "अप्रैल",
+        "मई",
+        "जून",
+        "जुल॰",
+        "अग॰",
+        "सित॰",
+        "अक्तू॰",
+        "नव॰",
+        "दिस॰",
+    ],
+    days_wide: [
+        "रविवार",
+        "सोमवार",
+        "मंगलवार",
+        "बुधवार",
+        "गुरुवार",
+        "शुक्रवार",
+        "शनिवार",
+    ],
+    days_abbr: ["रवि", "सोम", "मंगल", "बुध", "गुरु", "शुक्र", "शनि"],
+    am: "am",
+    pm: "pm",
+    hour12_default: true,
+};
+
+// Bengali - bn
+static BN: LocaleData = LocaleData {
+    date_formats: DateFormats {
+        full: "EEEE, d MMMM, y",
+        long: "d MMMM, y",
+        medium: "d MMM, y",
+        short: "d/M/yy",
+    },
+    time_formats: TimeFormats {
+        full: "h:mm:ss a zzzz",
+        long: "h:mm:ss a z",
+        medium: "h:mm:ss a",
+        short: "h:mm a",
+    },
+    datetime_pattern: "{1}, {0}",
+    months_wide: [
+        "জানুয়ারী",
+        "ফেব্রুয়ারী",
+        "মার্চ",
+        "এপ্রিল",
+        "মে",
+        "জুন",
+        "জুলাই",
+        "আগস্ট",
+        "সেপ্টেম্বর",
+        "অক্টোবর",
+        "নভেম্বর",
+        "ডিসেম্বর",
+    ],
+    months_abbr: [
+        "জানু",
+        "ফেব",
+        "মার্চ",
+        "এপ্রি",
+        "মে",
+        "জুন",
+        "জুলাই",
+        "আগ",
+        "সেপ",
+        "অক্টো",
+        "নভে",
+        "ডিসে",
+    ],
+    days_wide: [
+        "রবিবার",
+        "সোমবার",
+        "মঙ্গলবার",
+        "বুধবার",
+        "বৃহস্পতিবার",
+        "শুক্রবার",
+        "শনিবার",
+    ],
+    days_abbr: ["রবি", "সোম", "মঙ্গল", "বুধ", "বৃহস্পতি", "শুক্র", "শনি"],
+    am: "AM",
+    pm: "PM",
+    hour12_default: true,
+};
+
+// Vietnamese - vi
+static VI: LocaleData = LocaleData {
+    date_formats: DateFormats {
+        full: "EEEE, d MMMM, y",
+        long: "d MMMM, y",
+        medium: "d MMM, y",
+        short: "dd/MM/y",
+    },
+    time_formats: TimeFormats {
+        full: "HH:mm:ss zzzz",
+        long: "HH:mm:ss z",
+        medium: "HH:mm:ss",
+        short: "HH:mm",
+    },
+    datetime_pattern: "{1}, {0}",
+    months_wide: [
+        "tháng 1",
+        "tháng 2",
+        "tháng 3",
+        "tháng 4",
+        "tháng 5",
+        "tháng 6",
+        "tháng 7",
+        "tháng 8",
+        "tháng 9",
+        "tháng 10",
+        "tháng 11",
+        "tháng 12",
+    ],
+    months_abbr: [
+        "thg 1", "thg 2", "thg 3", "thg 4", "thg 5", "thg 6", "thg 7", "thg 8", "thg 9", "thg 10",
+        "thg 11", "thg 12",
+    ],
+    days_wide: [
+        "Chủ Nhật",
+        "Thứ Hai",
+        "Thứ Ba",
+        "Thứ Tư",
+        "Thứ Năm",
+        "Thứ Sáu",
+        "Thứ Bảy",
+    ],
+    days_abbr: ["CN", "Th 2", "Th 3", "Th 4", "Th 5", "Th 6", "Th 7"],
+    am: "SA",
+    pm: "CH",
+    hour12_default: false,
+};
+
+// Thai - th
+static TH: LocaleData = LocaleData {
+    date_formats: DateFormats {
+        full: "EEEEที่ d MMMM G y",
+        long: "d MMMM G y",
+        medium: "d MMM y",
+        short: "d/M/yy",
+    },
+    time_formats: TimeFormats {
+        full: "H นาฬิกา mm นาที ss วินาที zzzz",
+        long: "H นาฬิกา mm นาที ss วินาที z",
+        medium: "HH:mm:ss",
+        short: "HH:mm",
+    },
+    datetime_pattern: "{1} {0}",
+    months_wide: [
+        "มกราคม",
+        "กุมภาพันธ์",
+        "มีนาคม",
+        "เมษายน",
+        "พฤษภาคม",
+        "มิถุนายน",
+        "กรกฎาคม",
+        "สิงหาคม",
+        "กันยายน",
+        "ตุลาคม",
+        "พฤศจิกายน",
+        "ธันวาคม",
+    ],
+    months_abbr: [
+        "ม.ค.",
+        "ก.พ.",
+        "มี.ค.",
+        "เม.ย.",
+        "พ.ค.",
+        "มิ.ย.",
+        "ก.ค.",
+        "ส.ค.",
+        "ก.ย.",
+        "ต.ค.",
+        "พ.ย.",
+        "ธ.ค.",
+    ],
+    days_wide: [
+        "วันอาทิตย์",
+        "วันจันทร์",
+        "วันอังคาร",
+        "วันพุธ",
+        "วันพฤหัสบดี",
+        "วันศุกร์",
+        "วันเสาร์",
+    ],
+    days_abbr: ["อา.", "จ.", "อ.", "พ.", "พฤ.", "ศ.", "ส."],
+    am: "ก่อนเที่ยง",
+    pm: "หลังเที่ยง",
+    hour12_default: false,
+};
+
+// Indonesian - id
+static ID: LocaleData = LocaleData {
+    date_formats: DateFormats {
+        full: "EEEE, dd MMMM y",
+        long: "d MMMM y",
+        medium: "d MMM y",
+        short: "dd/MM/yy",
+    },
+    time_formats: TimeFormats {
+        full: "HH.mm.ss zzzz",
+        long: "HH.mm.ss z",
+        medium: "HH.mm.ss",
+        short: "HH.mm",
+    },
+    datetime_pattern: "{1} {0}",
+    months_wide: [
+        "Januari",
+        "Februari",
+        "Maret",
+        "April",
+        "Mei",
+        "Juni",
+        "Juli",
+        "Agustus",
+        "September",
+        "Oktober",
+        "November",
+        "Desember",
+    ],
+    months_abbr: [
+        "Jan", "Feb", "Mar", "Apr", "Mei", "Jun", "Jul", "Agu", "Sep", "Okt", "Nov", "Des",
+    ],
+    days_wide: [
+        "Minggu", "Senin", "Selasa", "Rabu", "Kamis", "Jumat", "Sabtu",
+    ],
+    days_abbr: ["Min", "Sen", "Sel", "Rab", "Kam", "Jum", "Sab"],
+    am: "AM",
+    pm: "PM",
+    hour12_default: false,
+};
+
+// Turkish - tr
+static TR: LocaleData = LocaleData {
+    date_formats: DateFormats {
+        full: "d MMMM y EEEE",
+        long: "d MMMM y",
+        medium: "d MMM y",
+        short: "d.MM.y",
+    },
+    time_formats: TimeFormats {
+        full: "HH:mm:ss zzzz",
+        long: "HH:mm:ss z",
+        medium: "HH:mm:ss",
+        short: "HH:mm",
+    },
+    datetime_pattern: "{1} {0}",
+    months_wide: [
+        "Ocak", "Şubat", "Mart", "Nisan", "Mayıs", "Haziran", "Temmuz", "Ağustos", "Eylül", "Ekim",
+        "Kasım", "Aralık",
+    ],
+    months_abbr: [
+        "Oca", "Şub", "Mar", "Nis", "May", "Haz", "Tem", "Ağu", "Eyl", "Eki", "Kas", "Ara",
+    ],
+    days_wide: [
+        "Pazar",
+        "Pazartesi",
+        "Salı",
+        "Çarşamba",
+        "Perşembe",
+        "Cuma",
+        "Cumartesi",
+    ],
+    days_abbr: ["Paz", "Pzt", "Sal", "Çar", "Per", "Cum", "Cmt"],
+    am: "ÖÖ",
+    pm: "ÖS",
+    hour12_default: false,
+};
+
+// Polish - pl
+static PL: LocaleData = LocaleData {
+    date_formats: DateFormats {
+        full: "EEEE, d MMMM y",
+        long: "d MMMM y",
+        medium: "d MMM y",
+        short: "dd.MM.y",
+    },
+    time_formats: TimeFormats {
+        full: "HH:mm:ss zzzz",
+        long: "HH:mm:ss z",
+        medium: "HH:mm:ss",
+        short: "HH:mm",
+    },
+    datetime_pattern: "{1}, {0}",
+    months_wide: [
+        "stycznia",
+        "lutego",
+        "marca",
+        "kwietnia",
+        "maja",
+        "czerwca",
+        "lipca",
+        "sierpnia",
+        "września",
+        "października",
+        "listopada",
+        "grudnia",
+    ],
+    months_abbr: [
+        "sty", "lut", "mar", "kwi", "maj", "cze", "lip", "sie", "wrz", "paź", "lis", "gru",
+    ],
+    days_wide: [
+        "niedziela",
+        "poniedziałek",
+        "wtorek",
+        "środa",
+        "czwartek",
+        "piątek",
+        "sobota",
+    ],
+    days_abbr: ["niedz.", "pon.", "wt.", "śr.", "czw.", "pt.", "sob."],
+    am: "AM",
+    pm: "PM",
+    hour12_default: false,
+};
+
+// Ukrainian - uk
+static UK: LocaleData = LocaleData {
+    date_formats: DateFormats {
+        full: "EEEE, d MMMM y 'р'.",
+        long: "d MMMM y 'р'.",
+        medium: "d MMM y 'р'.",
+        short: "dd.MM.yy",
+    },
+    time_formats: TimeFormats {
+        full: "HH:mm:ss zzzz",
+        long: "HH:mm:ss z",
+        medium: "HH:mm:ss",
+        short: "HH:mm",
+    },
+    datetime_pattern: "{1}, {0}",
+    months_wide: [
+        "січня",
+        "лютого",
+        "березня",
+        "квітня",
+        "травня",
+        "червня",
+        "липня",
+        "серпня",
+        "вересня",
+        "жовтня",
+        "листопада",
+        "грудня",
+    ],
+    months_abbr: [
+        "січ.",
+        "лют.",
+        "бер.",
+        "квіт.",
+        "трав.",
+        "черв.",
+        "лип.",
+        "серп.",
+        "вер.",
+        "жовт.",
+        "лист.",
+        "груд.",
+    ],
+    days_wide: [
+        "неділя",
+        "понеділок",
+        "вівторок",
+        "середа",
+        "четвер",
+        "пʼятниця",
+        "субота",
+    ],
+    days_abbr: ["нд", "пн", "вт", "ср", "чт", "пт", "сб"],
+    am: "дп",
+    pm: "пп",
+    hour12_default: false,
+};
+
+// Swedish - sv
+static SV: LocaleData = LocaleData {
+    date_formats: DateFormats {
+        full: "EEEE d MMMM y",
+        long: "d MMMM y",
+        medium: "d MMM y",
+        short: "y-MM-dd",
+    },
+    time_formats: TimeFormats {
+        full: "HH:mm:ss zzzz",
+        long: "HH:mm:ss z",
+        medium: "HH:mm:ss",
+        short: "HH:mm",
+    },
+    datetime_pattern: "{1} {0}",
+    months_wide: [
+        "januari",
+        "februari",
+        "mars",
+        "april",
+        "maj",
+        "juni",
+        "juli",
+        "augusti",
+        "september",
+        "oktober",
+        "november",
+        "december",
+    ],
+    months_abbr: [
+        "jan.", "feb.", "mars", "apr.", "maj", "juni", "juli", "aug.", "sep.", "okt.", "nov.",
+        "dec.",
+    ],
+    days_wide: [
+        "söndag", "måndag", "tisdag", "onsdag", "torsdag", "fredag", "lördag",
+    ],
+    days_abbr: ["sön", "mån", "tis", "ons", "tors", "fre", "lör"],
+    am: "fm",
+    pm: "em",
+    hour12_default: false,
+};
+
+// Danish - da
+static DA: LocaleData = LocaleData {
+    date_formats: DateFormats {
+        full: "EEEE 'den' d. MMMM y",
+        long: "d. MMMM y",
+        medium: "d. MMM y",
+        short: "dd.MM.y",
+    },
+    time_formats: TimeFormats {
+        full: "HH.mm.ss zzzz",
+        long: "HH.mm.ss z",
+        medium: "HH.mm.ss",
+        short: "HH.mm",
+    },
+    datetime_pattern: "{1} 'kl'. {0}",
+    months_wide: [
+        "januar",
+        "februar",
+        "marts",
+        "april",
+        "maj",
+        "juni",
+        "juli",
+        "august",
+        "september",
+        "oktober",
+        "november",
+        "december",
+    ],
+    months_abbr: [
+        "jan.", "feb.", "mar.", "apr.", "maj", "jun.", "jul.", "aug.", "sep.", "okt.", "nov.",
+        "dec.",
+    ],
+    days_wide: [
+        "søndag", "mandag", "tirsdag", "onsdag", "torsdag", "fredag", "lørdag",
+    ],
+    days_abbr: ["søn.", "man.", "tir.", "ons.", "tor.", "fre.", "lør."],
+    am: "AM",
+    pm: "PM",
+    hour12_default: false,
+};
+
+// Norwegian Bokmål - nb
+static NB: LocaleData = LocaleData {
+    date_formats: DateFormats {
+        full: "EEEE d. MMMM y",
+        long: "d. MMMM y",
+        medium: "d. MMM y",
+        short: "dd.MM.y",
+    },
+    time_formats: TimeFormats {
+        full: "HH:mm:ss zzzz",
+        long: "HH:mm:ss z",
+        medium: "HH:mm:ss",
+        short: "HH:mm",
+    },
+    datetime_pattern: "{1}, {0}",
+    months_wide: [
+        "januar",
+        "februar",
+        "mars",
+        "april",
+        "mai",
+        "juni",
+        "juli",
+        "august",
+        "september",
+        "oktober",
+        "november",
+        "desember",
+    ],
+    months_abbr: [
+        "jan.", "feb.", "mar.", "apr.", "mai", "jun.", "jul.", "aug.", "sep.", "okt.", "nov.",
+        "des.",
+    ],
+    days_wide: [
+        "søndag", "mandag", "tirsdag", "onsdag", "torsdag", "fredag", "lørdag",
+    ],
+    days_abbr: ["søn.", "man.", "tir.", "ons.", "tor.", "fre.", "lør."],
+    am: "a.m.",
+    pm: "p.m.",
+    hour12_default: false,
+};
+
+// Finnish - fi
+static FI: LocaleData = LocaleData {
+    date_formats: DateFormats {
+        full: "cccc d. MMMM y",
+        long: "d. MMMM y",
+        medium: "d.M.y",
+        short: "d.M.y",
+    },
+    time_formats: TimeFormats {
+        full: "H.mm.ss zzzz",
+        long: "H.mm.ss z",
+        medium: "H.mm.ss",
+        short: "H.mm",
+    },
+    datetime_pattern: "{1} 'klo' {0}",
+    months_wide: [
+        "tammikuuta",
+        "helmikuuta",
+        "maaliskuuta",
+        "huhtikuuta",
+        "toukokuuta",
+        "kesäkuuta",
+        "heinäkuuta",
+        "elokuuta",
+        "syyskuuta",
+        "lokakuuta",
+        "marraskuuta",
+        "joulukuuta",
+    ],
+    months_abbr: [
+        "tammik.", "helmik.", "maalisk.", "huhtik.", "toukok.", "kesäk.", "heinäk.", "elok.",
+        "syysk.", "lokak.", "marrask.", "jouluk.",
+    ],
+    days_wide: [
+        "sunnuntaina",
+        "maanantaina",
+        "tiistaina",
+        "keskiviikkona",
+        "torstaina",
+        "perjantaina",
+        "lauantaina",
+    ],
+    days_abbr: ["su", "ma", "ti", "ke", "to", "pe", "la"],
+    am: "ap.",
+    pm: "ip.",
+    hour12_default: false,
+};
+
+// Czech - cs
+static CS: LocaleData = LocaleData {
+    date_formats: DateFormats {
+        full: "EEEE d. MMMM y",
+        long: "d. MMMM y",
+        medium: "d. M. y",
+        short: "dd.MM.yy",
+    },
+    time_formats: TimeFormats {
+        full: "H:mm:ss zzzz",
+        long: "H:mm:ss z",
+        medium: "H:mm:ss",
+        short: "H:mm",
+    },
+    datetime_pattern: "{1} {0}",
+    months_wide: [
+        "ledna",
+        "února",
+        "března",
+        "dubna",
+        "května",
+        "června",
+        "července",
+        "srpna",
+        "září",
+        "října",
+        "listopadu",
+        "prosince",
+    ],
+    months_abbr: [
+        "led", "úno", "bře", "dub", "kvě", "čvn", "čvc", "srp", "zář", "říj", "lis", "pro",
+    ],
+    days_wide: [
+        "neděle",
+        "pondělí",
+        "úterý",
+        "středa",
+        "čtvrtek",
+        "pátek",
+        "sobota",
+    ],
+    days_abbr: ["ne", "po", "út", "st", "čt", "pá", "so"],
+    am: "dop.",
+    pm: "odp.",
+    hour12_default: false,
+};
+
+// Greek - el
+static EL: LocaleData = LocaleData {
+    date_formats: DateFormats {
+        full: "EEEE d MMMM y",
+        long: "d MMMM y",
+        medium: "d MMM y",
+        short: "d/M/yy",
+    },
+    time_formats: TimeFormats {
+        full: "h:mm:ss a zzzz",
+        long: "h:mm:ss a z",
+        medium: "h:mm:ss a",
+        short: "h:mm a",
+    },
+    datetime_pattern: "{1}, {0}",
+    months_wide: [
+        "Ιανουαρίου",
+        "Φεβρουαρίου",
+        "Μαρτίου",
+        "Απριλίου",
+        "Μαΐου",
+        "Ιουνίου",
+        "Ιουλίου",
+        "Αυγούστου",
+        "Σεπτεμβρίου",
+        "Οκτωβρίου",
+        "Νοεμβρίου",
+        "Δεκεμβρίου",
+    ],
+    months_abbr: [
+        "Ιαν", "Φεβ", "Μαρ", "Απρ", "Μαΐ", "Ιουν", "Ιουλ", "Αυγ", "Σεπ", "Οκτ", "Νοε", "Δεκ",
+    ],
+    days_wide: [
+        "Κυριακή",
+        "Δευτέρα",
+        "Τρίτη",
+        "Τετάρτη",
+        "Πέμπτη",
+        "Παρασκευή",
+        "Σάββατο",
+    ],
+    days_abbr: ["Κυρ", "Δευ", "Τρί", "Τετ", "Πέμ", "Παρ", "Σάβ"],
+    am: "π.μ.",
+    pm: "μ.μ.",
+    hour12_default: true,
+};
+
+// Hebrew - he
+static HE: LocaleData = LocaleData {
+    date_formats: DateFormats {
+        full: "EEEE, d בMMMM y",
+        long: "d בMMMM y",
+        medium: "d בMMM y",
+        short: "d.M.y",
+    },
+    time_formats: TimeFormats {
+        full: "H:mm:ss zzzz",
+        long: "H:mm:ss z",
+        medium: "H:mm:ss",
+        short: "H:mm",
+    },
+    datetime_pattern: "{1}, {0}",
+    months_wide: [
+        "ינואר",
+        "פברואר",
+        "מרץ",
+        "אפריל",
+        "מאי",
+        "יוני",
+        "יולי",
+        "אוגוסט",
+        "ספטמבר",
+        "אוקטובר",
+        "נובמבר",
+        "דצמבר",
+    ],
+    months_abbr: [
+        "ינו׳", "פבר׳", "מרץ", "אפר׳", "מאי", "יוני", "יולי", "אוג׳", "ספט׳", "אוק׳", "נוב׳",
+        "דצמ׳",
+    ],
+    days_wide: [
+        "יום ראשון",
+        "יום שני",
+        "יום שלישי",
+        "יום רביעי",
+        "יום חמישי",
+        "יום שישי",
+        "יום שבת",
+    ],
+    days_abbr: [
+        "יום א׳",
+        "יום ב׳",
+        "יום ג׳",
+        "יום ד׳",
+        "יום ה׳",
+        "יום ו׳",
+        "שבת",
+    ],
+    am: "לפנה״צ",
+    pm: "אחה״צ",
+    hour12_default: false,
+};
+
+// Hungarian - hu
+static HU: LocaleData = LocaleData {
+    date_formats: DateFormats {
+        full: "y. MMMM d., EEEE",
+        long: "y. MMMM d.",
+        medium: "y. MMM d.",
+        short: "y. MM. dd.",
+    },
+    time_formats: TimeFormats {
+        full: "H:mm:ss zzzz",
+        long: "H:mm:ss z",
+        medium: "H:mm:ss",
+        short: "H:mm",
+    },
+    datetime_pattern: "{1} {0}",
+    months_wide: [
+        "január",
+        "február",
+        "március",
+        "április",
+        "május",
+        "június",
+        "július",
+        "augusztus",
+        "szeptember",
+        "október",
+        "november",
+        "december",
+    ],
+    months_abbr: [
+        "jan.", "febr.", "márc.", "ápr.", "máj.", "jún.", "júl.", "aug.", "szept.", "okt.", "nov.",
+        "dec.",
+    ],
+    days_wide: [
+        "vasárnap",
+        "hétfő",
+        "kedd",
+        "szerda",
+        "csütörtök",
+        "péntek",
+        "szombat",
+    ],
+    days_abbr: ["V", "H", "K", "Sze", "Cs", "P", "Szo"],
+    am: "de.",
+    pm: "du.",
+    hour12_default: false,
+};
+
+// Romanian - ro
+static RO: LocaleData = LocaleData {
+    date_formats: DateFormats {
+        full: "EEEE, d MMMM y",
+        long: "d MMMM y",
+        medium: "d MMM y",
+        short: "dd.MM.y",
+    },
+    time_formats: TimeFormats {
+        full: "HH:mm:ss zzzz",
+        long: "HH:mm:ss z",
+        medium: "HH:mm:ss",
+        short: "HH:mm",
+    },
+    datetime_pattern: "{1}, {0}",
+    months_wide: [
+        "ianuarie",
+        "februarie",
+        "martie",
+        "aprilie",
+        "mai",
+        "iunie",
+        "iulie",
+        "august",
+        "septembrie",
+        "octombrie",
+        "noiembrie",
+        "decembrie",
+    ],
+    months_abbr: [
+        "ian.", "feb.", "mar.", "apr.", "mai", "iun.", "iul.", "aug.", "sept.", "oct.", "nov.",
+        "dec.",
+    ],
+    days_wide: [
+        "duminică",
+        "luni",
+        "marți",
+        "miercuri",
+        "joi",
+        "vineri",
+        "sâmbătă",
+    ],
+    days_abbr: ["dum.", "lun.", "mar.", "mie.", "joi", "vin.", "sâm."],
+    am: "a.m.",
+    pm: "p.m.",
+    hour12_default: false,
+};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_get_locale_data_exact_match() {
+        let data = get_locale_data("en-US");
+        assert_eq!(data.date_formats.short, "M/d/yy");
+        assert!(data.hour12_default);
+
+        let data = get_locale_data("de-DE");
+        assert_eq!(data.date_formats.short, "dd.MM.yy");
+        assert!(!data.hour12_default);
+    }
+
+    #[test]
+    fn test_get_locale_data_language_fallback() {
+        let data = get_locale_data("de");
+        assert_eq!(data.date_formats.short, "dd.MM.yy");
+
+        let data = get_locale_data("fr");
+        assert_eq!(data.date_formats.short, "dd/MM/y");
+    }
+
+    #[test]
+    fn test_get_locale_data_unknown_fallback() {
+        let data = get_locale_data("xx-YY");
+        // Should fall back to en-US
+        assert_eq!(data.date_formats.short, "M/d/yy");
+    }
+
+    #[test]
+    fn test_get_locale_data_case_insensitive() {
+        let data1 = get_locale_data("en-US");
+        let data2 = get_locale_data("EN-US");
+        let data3 = get_locale_data("En-Us");
+        assert_eq!(data1.date_formats.short, data2.date_formats.short);
+        assert_eq!(data2.date_formats.short, data3.date_formats.short);
+    }
+
+    #[test]
+    fn test_get_locale_data_underscore() {
+        let data = get_locale_data("en_US");
+        assert_eq!(data.date_formats.short, "M/d/yy");
+    }
+
+    #[test]
+    fn test_months_count() {
+        let data = get_locale_data("en-US");
+        assert_eq!(data.months_wide.len(), 12);
+        assert_eq!(data.months_abbr.len(), 12);
+    }
+
+    #[test]
+    fn test_days_count() {
+        let data = get_locale_data("en-US");
+        assert_eq!(data.days_wide.len(), 7);
+        assert_eq!(data.days_abbr.len(), 7);
+    }
+}

--- a/modules/src/intl/date_time_format.rs
+++ b/modules/src/intl/date_time_format.rs
@@ -1,0 +1,799 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Minimal Intl.DateTimeFormat implementation for timezone support.
+//! This provides just enough functionality to support dayjs and similar libraries.
+
+use chrono::{DateTime, Datelike, Offset, TimeZone, Timelike, Utc};
+use chrono_tz::Tz;
+use rsquickjs::{
+    atom::PredefinedAtom, prelude::Opt, Array, Coerced, Ctx, Exception, Object, Result, Value,
+};
+
+/// Stores the resolved options for a DateTimeFormat instance
+#[derive(Clone, Debug)]
+pub struct DateTimeFormatOptions {
+    pub locale: String,
+    pub timezone: Tz,
+    pub hour12: bool,
+    pub year: Option<String>,
+    pub month: Option<String>,
+    pub day: Option<String>,
+    pub hour: Option<String>,
+    pub minute: Option<String>,
+    pub second: Option<String>,
+    pub weekday: Option<String>,
+    pub timezone_name: Option<String>,
+    pub fractional_second_digits: Option<u8>,
+}
+
+impl Default for DateTimeFormatOptions {
+    fn default() -> Self {
+        Self {
+            locale: "en-US".to_string(),
+            timezone: chrono_tz::UTC,
+            hour12: false,
+            year: None,
+            month: None,
+            day: None,
+            hour: None,
+            minute: None,
+            second: None,
+            weekday: None,
+            timezone_name: None,
+            fractional_second_digits: None,
+        }
+    }
+}
+
+/// A formatted part with type and value
+#[derive(Debug, Clone)]
+pub struct FormatPart {
+    pub part_type: &'static str,
+    pub value: String,
+}
+
+impl FormatPart {
+    #[inline]
+    fn new(part_type: &'static str, value: String) -> Self {
+        Self { part_type, value }
+    }
+
+    #[inline]
+    fn literal(value: &'static str) -> Self {
+        Self {
+            part_type: "literal",
+            value: value.to_string(),
+        }
+    }
+}
+
+/// Format a number with optional zero-padding
+#[inline]
+fn format_number(value: u32, two_digit: bool) -> String {
+    let mut buf = itoa::Buffer::new();
+    if two_digit && value < 10 {
+        let mut result = String::with_capacity(2);
+        result.push('0');
+        result.push_str(buf.format(value));
+        result
+    } else {
+        buf.format(value).to_string()
+    }
+}
+
+/// Format a number component based on option style
+#[inline]
+fn format_component(value: u32, style: Option<&str>) -> String {
+    let two_digit = matches!(style, Some("2-digit"));
+    format_number(value, two_digit)
+}
+
+/// Build format parts from a DateTime in pure Rust
+fn build_format_parts(local_dt: &DateTime<Tz>, options: &DateTimeFormatOptions) -> Vec<FormatPart> {
+    let mut parts = Vec::with_capacity(16);
+
+    // Month
+    if let Some(ref month_opt) = options.month {
+        parts.push(FormatPart::new(
+            "month",
+            format_component(local_dt.month(), Some(month_opt)),
+        ));
+        parts.push(FormatPart::literal("/"));
+    }
+
+    // Day
+    if let Some(ref day_opt) = options.day {
+        parts.push(FormatPart::new(
+            "day",
+            format_component(local_dt.day(), Some(day_opt)),
+        ));
+        parts.push(FormatPart::literal("/"));
+    }
+
+    // Year
+    if let Some(ref year_opt) = options.year {
+        let year_val = if year_opt == "2-digit" {
+            format_number((local_dt.year() % 100) as u32, true)
+        } else {
+            let mut buf = itoa::Buffer::new();
+            buf.format(local_dt.year()).to_string()
+        };
+        parts.push(FormatPart::new("year", year_val));
+    }
+
+    // Add separator between date and time if we have both
+    let has_date = options.year.is_some() || options.month.is_some() || options.day.is_some();
+    let has_time = options.hour.is_some() || options.minute.is_some() || options.second.is_some();
+
+    if has_date && has_time {
+        parts.push(FormatPart::literal(", "));
+    }
+
+    // Hour
+    if options.hour.is_some() {
+        let hour = local_dt.hour();
+        let hour_val = if options.hour12 {
+            match hour {
+                0 => 12,
+                13..=23 => hour - 12,
+                _ => hour,
+            }
+        } else {
+            hour
+        };
+
+        parts.push(FormatPart::new(
+            "hour",
+            format_component(hour_val, options.hour.as_deref()),
+        ));
+
+        if options.minute.is_some() || options.second.is_some() {
+            parts.push(FormatPart::literal(":"));
+        }
+    }
+
+    // Minute
+    if options.minute.is_some() {
+        parts.push(FormatPart::new(
+            "minute",
+            format_component(local_dt.minute(), options.minute.as_deref()),
+        ));
+
+        if options.second.is_some() {
+            parts.push(FormatPart::literal(":"));
+        }
+    }
+
+    // Second
+    if options.second.is_some() {
+        parts.push(FormatPart::new(
+            "second",
+            format_component(local_dt.second(), options.second.as_deref()),
+        ));
+    }
+
+    // dayPeriod for 12-hour format
+    if options.hour12 && options.hour.is_some() {
+        let hour = local_dt.hour();
+        parts.push(FormatPart::literal(" "));
+        parts.push(FormatPart::new(
+            "dayPeriod",
+            if hour >= 12 { "PM" } else { "AM" }.to_string(),
+        ));
+    }
+
+    // Timezone name
+    if let Some(ref tz_name_opt) = options.timezone_name {
+        parts.push(FormatPart::literal(" "));
+        let tz_str = format_timezone_name(local_dt, &options.timezone, tz_name_opt);
+        parts.push(FormatPart::new("timeZoneName", tz_str));
+    }
+
+    parts
+}
+
+/// Format timezone name based on style option
+fn format_timezone_name(local_dt: &DateTime<Tz>, timezone: &Tz, style: &str) -> String {
+    match style {
+        "short" | "shortOffset" => {
+            let offset = local_dt.offset().fix();
+            let total_secs = offset.local_minus_utc();
+            let hours = total_secs / 3600;
+            let mins = (total_secs % 3600).abs() / 60;
+
+            let mut result = String::with_capacity(10);
+            result.push_str("GMT");
+
+            if hours >= 0 {
+                result.push('+');
+            }
+
+            let mut buf = itoa::Buffer::new();
+            result.push_str(buf.format(hours));
+
+            if mins != 0 && style == "shortOffset" {
+                result.push(':');
+                if mins < 10 {
+                    result.push('0');
+                }
+                result.push_str(buf.format(mins));
+            }
+
+            result
+        },
+        "long" => timezone.name().to_string(),
+        _ => timezone.name().to_string(),
+    }
+}
+
+/// Convert format parts Vec to JS Array
+fn parts_to_js_array<'js>(ctx: &Ctx<'js>, parts: Vec<FormatPart>) -> Result<Array<'js>> {
+    let array = Array::new(ctx.clone())?;
+    for (idx, part) in parts.into_iter().enumerate() {
+        let obj = Object::new(ctx.clone())?;
+        obj.set("type", part.part_type)?;
+        obj.set("value", part.value)?;
+        array.set(idx, obj)?;
+    }
+    Ok(array)
+}
+
+/// Join format parts into a single string
+fn parts_to_string(parts: &[FormatPart]) -> String {
+    let total_len: usize = parts.iter().map(|p| p.value.len()).sum();
+    let mut result = String::with_capacity(total_len);
+    for part in parts {
+        result.push_str(&part.value);
+    }
+    result
+}
+
+/// Parse epoch milliseconds from a Date value
+fn parse_epoch_ms<'js>(ctx: &Ctx<'js>, date: Opt<Value<'js>>) -> Result<f64> {
+    if let Some(date_val) = date.into_inner() {
+        if date_val.is_undefined() {
+            Ok(Utc::now().timestamp_millis() as f64)
+        } else if let Some(num) = date_val.as_number() {
+            Ok(num)
+        } else {
+            date_val
+                .get::<Coerced<f64>>()
+                .map(|c| c.0)
+                .map_err(|_| Exception::throw_type(ctx, "Invalid date"))
+        }
+    } else {
+        Ok(Utc::now().timestamp_millis() as f64)
+    }
+}
+
+/// Convert epoch milliseconds to DateTime in the specified timezone
+fn epoch_to_datetime(ctx: &Ctx<'_>, epoch_ms: f64, timezone: &Tz) -> Result<DateTime<Tz>> {
+    let epoch_secs = (epoch_ms / 1000.0) as i64;
+    let epoch_nanos = ((epoch_ms % 1000.0) * 1_000_000.0) as u32;
+
+    let utc_dt = Utc
+        .timestamp_opt(epoch_secs, epoch_nanos)
+        .single()
+        .ok_or_else(|| Exception::throw_range(ctx, "Invalid timestamp"))?;
+
+    Ok(utc_dt.with_timezone(timezone))
+}
+
+/// Minimal Intl.DateTimeFormat implementation
+#[derive(Clone, rsquickjs::class::Trace, rsquickjs::JsLifetime)]
+#[rsquickjs::class]
+pub struct DateTimeFormat {
+    #[qjs(skip_trace)]
+    options: DateTimeFormatOptions,
+}
+
+#[rsquickjs::methods(rename_all = "camelCase")]
+impl DateTimeFormat {
+    #[qjs(constructor)]
+    pub fn new(ctx: Ctx<'_>, locales: Opt<Value<'_>>, options: Opt<Object<'_>>) -> Result<Self> {
+        let mut opts = DateTimeFormatOptions::default();
+
+        // Parse locale (we only care about extracting the language tag)
+        if let Some(locale_val) = locales.into_inner() {
+            if let Some(s) = locale_val.as_string() {
+                opts.locale = s.to_string()?;
+            } else if let Some(arr) = locale_val.as_array() {
+                if let Ok(first) = arr.get::<Value>(0) {
+                    if let Some(s) = first.as_string() {
+                        opts.locale = s.to_string()?;
+                    }
+                }
+            }
+        }
+
+        // Parse options
+        if let Some(options_obj) = options.into_inner() {
+            // timeZone
+            if let Ok(tz_val) = options_obj.get::<_, String>("timeZone") {
+                opts.timezone = tz_val.parse().map_err(|_| {
+                    Exception::throw_range(&ctx, &["Invalid time zone: ", &tz_val].concat())
+                })?;
+            }
+
+            // hour12
+            if let Ok(h12) = options_obj.get::<_, bool>("hour12") {
+                opts.hour12 = h12;
+            }
+
+            // Date/time components
+            if let Ok(v) = options_obj.get::<_, String>("year") {
+                opts.year = Some(v);
+            }
+            if let Ok(v) = options_obj.get::<_, String>("month") {
+                opts.month = Some(v);
+            }
+            if let Ok(v) = options_obj.get::<_, String>("day") {
+                opts.day = Some(v);
+            }
+            if let Ok(v) = options_obj.get::<_, String>("hour") {
+                opts.hour = Some(v);
+            }
+            if let Ok(v) = options_obj.get::<_, String>("minute") {
+                opts.minute = Some(v);
+            }
+            if let Ok(v) = options_obj.get::<_, String>("second") {
+                opts.second = Some(v);
+            }
+            if let Ok(v) = options_obj.get::<_, String>("weekday") {
+                opts.weekday = Some(v);
+            }
+            if let Ok(v) = options_obj.get::<_, String>("timeZoneName") {
+                opts.timezone_name = Some(v);
+            }
+            if let Ok(v) = options_obj.get::<_, u8>("fractionalSecondDigits") {
+                opts.fractional_second_digits = Some(v);
+            }
+        }
+
+        Ok(Self { options: opts })
+    }
+
+    /// Format a date according to the locale and options
+    pub fn format<'js>(&self, ctx: Ctx<'js>, date: Opt<Value<'js>>) -> Result<String> {
+        let epoch_ms = parse_epoch_ms(&ctx, date)?;
+        let local_dt = epoch_to_datetime(&ctx, epoch_ms, &self.options.timezone)?;
+        let parts = build_format_parts(&local_dt, &self.options);
+        Ok(parts_to_string(&parts))
+    }
+
+    /// Format a date to parts
+    #[qjs(rename = "formatToParts")]
+    pub fn format_to_parts<'js>(&self, ctx: Ctx<'js>, date: Opt<Value<'js>>) -> Result<Array<'js>> {
+        let epoch_ms = parse_epoch_ms(&ctx, date)?;
+        let local_dt = epoch_to_datetime(&ctx, epoch_ms, &self.options.timezone)?;
+        let parts = build_format_parts(&local_dt, &self.options);
+        parts_to_js_array(&ctx, parts)
+    }
+
+    /// Return resolved options
+    #[qjs(rename = "resolvedOptions")]
+    pub fn resolved_options<'js>(&self, ctx: Ctx<'js>) -> Result<Object<'js>> {
+        let obj = Object::new(ctx)?;
+
+        obj.set("locale", self.options.locale.as_str())?;
+        obj.set("calendar", "gregory")?;
+        obj.set("numberingSystem", "latn")?;
+        obj.set("timeZone", self.options.timezone.name())?;
+
+        if self.options.hour.is_some() {
+            obj.set("hour12", self.options.hour12)?;
+            obj.set("hourCycle", if self.options.hour12 { "h12" } else { "h23" })?;
+        }
+
+        if let Some(ref v) = self.options.year {
+            obj.set("year", v.as_str())?;
+        }
+        if let Some(ref v) = self.options.month {
+            obj.set("month", v.as_str())?;
+        }
+        if let Some(ref v) = self.options.day {
+            obj.set("day", v.as_str())?;
+        }
+        if let Some(ref v) = self.options.hour {
+            obj.set("hour", v.as_str())?;
+        }
+        if let Some(ref v) = self.options.minute {
+            obj.set("minute", v.as_str())?;
+        }
+        if let Some(ref v) = self.options.second {
+            obj.set("second", v.as_str())?;
+        }
+        if let Some(ref v) = self.options.weekday {
+            obj.set("weekday", v.as_str())?;
+        }
+        if let Some(ref v) = self.options.timezone_name {
+            obj.set("timeZoneName", v.as_str())?;
+        }
+
+        Ok(obj)
+    }
+
+    #[qjs(get, rename = PredefinedAtom::SymbolToStringTag)]
+    pub fn to_string_tag(&self) -> &'static str {
+        "Intl.DateTimeFormat"
+    }
+}
+
+/// Get the system's default timezone
+pub fn get_system_timezone() -> String {
+    iana_time_zone::get_timezone().unwrap_or_else(|_| "UTC".to_string())
+}
+
+/// Format a date in the specified timezone using locale options.
+/// This is used to implement Date.prototype.toLocaleString with timezone support.
+pub fn format_date_in_timezone(
+    epoch_ms: f64,
+    timezone: &Tz,
+    options: &ToLocaleStringOptions,
+) -> String {
+    let epoch_secs = (epoch_ms / 1000.0) as i64;
+    let epoch_nanos = ((epoch_ms % 1000.0) * 1_000_000.0) as u32;
+
+    let utc_dt = match Utc.timestamp_opt(epoch_secs, epoch_nanos).single() {
+        Some(dt) => dt,
+        None => return String::new(),
+    };
+
+    let local_dt = utc_dt.with_timezone(timezone);
+
+    // Format as MM/DD/YYYY, HH:MM:SS AM/PM (en-US style)
+    let month = local_dt.month();
+    let day = local_dt.day();
+    let year = local_dt.year();
+    let hour = local_dt.hour();
+    let minute = local_dt.minute();
+    let second = local_dt.second();
+
+    let mut buf = itoa::Buffer::new();
+    let mut result = String::with_capacity(24);
+
+    // Month (zero-padded)
+    if month < 10 {
+        result.push('0');
+    }
+    result.push_str(buf.format(month));
+    result.push('/');
+
+    // Day (zero-padded)
+    if day < 10 {
+        result.push('0');
+    }
+    result.push_str(buf.format(day));
+    result.push('/');
+
+    // Year
+    result.push_str(buf.format(year));
+    result.push_str(", ");
+
+    if options.hour12 {
+        let (hour12, period) = match hour {
+            0 => (12, "AM"),
+            1..=11 => (hour, "AM"),
+            12 => (12, "PM"),
+            _ => (hour - 12, "PM"),
+        };
+
+        // Hour (no padding for 12-hour format)
+        result.push_str(buf.format(hour12));
+        result.push(':');
+
+        // Minute (zero-padded)
+        if minute < 10 {
+            result.push('0');
+        }
+        result.push_str(buf.format(minute));
+        result.push(':');
+
+        // Second (zero-padded)
+        if second < 10 {
+            result.push('0');
+        }
+        result.push_str(buf.format(second));
+
+        result.push(' ');
+        result.push_str(period);
+    } else {
+        // Hour (zero-padded)
+        if hour < 10 {
+            result.push('0');
+        }
+        result.push_str(buf.format(hour));
+        result.push(':');
+
+        // Minute (zero-padded)
+        if minute < 10 {
+            result.push('0');
+        }
+        result.push_str(buf.format(minute));
+        result.push(':');
+
+        // Second (zero-padded)
+        if second < 10 {
+            result.push('0');
+        }
+        result.push_str(buf.format(second));
+    }
+
+    result
+}
+
+/// Options for toLocaleString
+#[derive(Default)]
+pub struct ToLocaleStringOptions {
+    pub hour12: bool,
+    pub hour12_set: bool,
+    pub date_style: Option<String>,
+    pub time_style: Option<String>,
+}
+
+/// Parse toLocaleString options from a JavaScript object
+pub fn parse_to_locale_string_options<'js>(
+    ctx: &Ctx<'js>,
+    options: Option<Object<'js>>,
+) -> Result<(Option<Tz>, ToLocaleStringOptions)> {
+    let mut tz: Option<Tz> = None;
+    let mut opts = ToLocaleStringOptions::default();
+
+    if let Some(options_obj) = options {
+        // Parse timeZone
+        if let Ok(tz_val) = options_obj.get::<_, String>("timeZone") {
+            tz = Some(tz_val.parse().map_err(|_| {
+                Exception::throw_range(ctx, &["Invalid time zone: ", &tz_val].concat())
+            })?);
+        }
+
+        // Parse hour12
+        if let Ok(h12) = options_obj.get::<_, bool>("hour12") {
+            opts.hour12 = h12;
+            opts.hour12_set = true;
+        }
+
+        // Parse dateStyle
+        if let Ok(ds) = options_obj.get::<_, String>("dateStyle") {
+            opts.date_style = Some(ds);
+        }
+
+        // Parse timeStyle
+        if let Ok(ts) = options_obj.get::<_, String>("timeStyle") {
+            opts.time_style = Some(ts);
+        }
+    }
+
+    Ok((tz, opts))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_format_number() {
+        assert_eq!(format_number(5, false), "5");
+        assert_eq!(format_number(5, true), "05");
+        assert_eq!(format_number(12, true), "12");
+        assert_eq!(format_number(0, true), "00");
+    }
+
+    #[test]
+    fn test_format_component() {
+        assert_eq!(format_component(5, Some("2-digit")), "05");
+        assert_eq!(format_component(5, Some("numeric")), "5");
+        assert_eq!(format_component(12, Some("2-digit")), "12");
+        assert_eq!(format_component(12, None), "12");
+    }
+
+    #[test]
+    fn test_build_format_parts_date_only() {
+        let tz: Tz = "UTC".parse().unwrap();
+        // 2024-03-15 10:30:45 UTC
+        let epoch_ms = 1710499845000.0;
+        let epoch_secs = (epoch_ms / 1000.0) as i64;
+        let utc_dt = Utc.timestamp_opt(epoch_secs, 0).unwrap();
+        let local_dt = utc_dt.with_timezone(&tz);
+
+        let options = DateTimeFormatOptions {
+            year: Some("numeric".to_string()),
+            month: Some("2-digit".to_string()),
+            day: Some("2-digit".to_string()),
+            ..Default::default()
+        };
+
+        let parts = build_format_parts(&local_dt, &options);
+
+        assert_eq!(parts.len(), 5); // month, /, day, /, year
+        assert_eq!(parts[0].part_type, "month");
+        assert_eq!(parts[0].value, "03");
+        assert_eq!(parts[1].part_type, "literal");
+        assert_eq!(parts[1].value, "/");
+        assert_eq!(parts[2].part_type, "day");
+        assert_eq!(parts[2].value, "15");
+        assert_eq!(parts[4].part_type, "year");
+        assert_eq!(parts[4].value, "2024");
+    }
+
+    #[test]
+    fn test_build_format_parts_time_only() {
+        let tz: Tz = "UTC".parse().unwrap();
+        // 2024-03-15 10:30:45 UTC
+        let epoch_ms = 1710498645000.0;
+        let epoch_secs = (epoch_ms / 1000.0) as i64;
+        let utc_dt = Utc.timestamp_opt(epoch_secs, 0).unwrap();
+        let local_dt = utc_dt.with_timezone(&tz);
+
+        let options = DateTimeFormatOptions {
+            hour: Some("2-digit".to_string()),
+            minute: Some("2-digit".to_string()),
+            second: Some("2-digit".to_string()),
+            ..Default::default()
+        };
+
+        let parts = build_format_parts(&local_dt, &options);
+
+        assert_eq!(parts[0].part_type, "hour");
+        assert_eq!(parts[0].value, "10");
+        assert_eq!(parts[2].part_type, "minute");
+        assert_eq!(parts[2].value, "30");
+        assert_eq!(parts[4].part_type, "second");
+        assert_eq!(parts[4].value, "45");
+    }
+
+    #[test]
+    fn test_build_format_parts_12hour() {
+        let tz: Tz = "UTC".parse().unwrap();
+        // 2024-03-15 14:30:00 UTC (2 PM)
+        let epoch_ms = 1710514200000.0;
+        let epoch_secs = (epoch_ms / 1000.0) as i64;
+        let utc_dt = Utc.timestamp_opt(epoch_secs, 0).unwrap();
+        let local_dt = utc_dt.with_timezone(&tz);
+
+        let options = DateTimeFormatOptions {
+            hour: Some("numeric".to_string()),
+            hour12: true,
+            ..Default::default()
+        };
+
+        let parts = build_format_parts(&local_dt, &options);
+
+        assert_eq!(parts[0].part_type, "hour");
+        assert_eq!(parts[0].value, "2"); // 14:00 -> 2 PM
+        assert_eq!(parts[2].part_type, "dayPeriod");
+        assert_eq!(parts[2].value, "PM");
+    }
+
+    #[test]
+    fn test_build_format_parts_midnight_12hour() {
+        let tz: Tz = "UTC".parse().unwrap();
+        // 2024-03-15 00:30:00 UTC (12:30 AM)
+        let epoch_ms = 1710463800000.0;
+        let epoch_secs = (epoch_ms / 1000.0) as i64;
+        let utc_dt = Utc.timestamp_opt(epoch_secs, 0).unwrap();
+        let local_dt = utc_dt.with_timezone(&tz);
+
+        let options = DateTimeFormatOptions {
+            hour: Some("numeric".to_string()),
+            hour12: true,
+            ..Default::default()
+        };
+
+        let parts = build_format_parts(&local_dt, &options);
+
+        assert_eq!(parts[0].part_type, "hour");
+        assert_eq!(parts[0].value, "12"); // 00:00 -> 12 AM
+        assert_eq!(parts[2].part_type, "dayPeriod");
+        assert_eq!(parts[2].value, "AM");
+    }
+
+    #[test]
+    fn test_format_timezone_name_short() {
+        let tz: Tz = "America/New_York".parse().unwrap();
+        // Summer time (EDT = UTC-4)
+        let epoch_ms = 1720000000000.0; // July 2024
+        let epoch_secs = (epoch_ms / 1000.0) as i64;
+        let utc_dt = Utc.timestamp_opt(epoch_secs, 0).unwrap();
+        let local_dt = utc_dt.with_timezone(&tz);
+
+        let result = format_timezone_name(&local_dt, &tz, "short");
+        assert_eq!(result, "GMT-4");
+    }
+
+    #[test]
+    fn test_format_timezone_name_long() {
+        let tz: Tz = "America/New_York".parse().unwrap();
+        let epoch_ms = 1720000000000.0;
+        let epoch_secs = (epoch_ms / 1000.0) as i64;
+        let utc_dt = Utc.timestamp_opt(epoch_secs, 0).unwrap();
+        let local_dt = utc_dt.with_timezone(&tz);
+
+        let result = format_timezone_name(&local_dt, &tz, "long");
+        assert_eq!(result, "America/New_York");
+    }
+
+    #[test]
+    fn test_parts_to_string() {
+        let parts = vec![
+            FormatPart::new("month", "03".to_string()),
+            FormatPart::literal("/"),
+            FormatPart::new("day", "15".to_string()),
+            FormatPart::literal("/"),
+            FormatPart::new("year", "2024".to_string()),
+        ];
+
+        assert_eq!(parts_to_string(&parts), "03/15/2024");
+    }
+
+    #[test]
+    fn test_format_date_in_timezone() {
+        // 2024-03-15 14:30:45 UTC
+        let epoch_ms = 1710513045000.0;
+        let tz: Tz = "UTC".parse().unwrap();
+
+        let opts = ToLocaleStringOptions {
+            hour12: true,
+            ..Default::default()
+        };
+        let result = format_date_in_timezone(epoch_ms, &tz, &opts);
+        assert_eq!(result, "03/15/2024, 2:30:45 PM");
+
+        let opts = ToLocaleStringOptions {
+            hour12: false,
+            ..Default::default()
+        };
+        let result = format_date_in_timezone(epoch_ms, &tz, &opts);
+        assert_eq!(result, "03/15/2024, 14:30:45");
+    }
+
+    #[test]
+    fn test_format_date_in_timezone_with_tz() {
+        // 2024-03-15 14:30:45 UTC -> 10:30:45 AM EDT (UTC-4)
+        let epoch_ms = 1710513045000.0;
+        let tz: Tz = "America/New_York".parse().unwrap();
+
+        let opts = ToLocaleStringOptions {
+            hour12: true,
+            ..Default::default()
+        };
+        let result = format_date_in_timezone(epoch_ms, &tz, &opts);
+        assert_eq!(result, "03/15/2024, 10:30:45 AM");
+    }
+
+    #[test]
+    fn test_format_date_midnight() {
+        // 2024-03-15 00:00:00 UTC
+        let epoch_ms = 1710460800000.0;
+        let tz: Tz = "UTC".parse().unwrap();
+
+        let opts = ToLocaleStringOptions {
+            hour12: true,
+            ..Default::default()
+        };
+        let result = format_date_in_timezone(epoch_ms, &tz, &opts);
+        assert_eq!(result, "03/15/2024, 12:00:00 AM");
+
+        let opts = ToLocaleStringOptions {
+            hour12: false,
+            ..Default::default()
+        };
+        let result = format_date_in_timezone(epoch_ms, &tz, &opts);
+        assert_eq!(result, "03/15/2024, 00:00:00");
+    }
+
+    #[test]
+    fn test_format_date_noon() {
+        // 2024-03-15 12:00:00 UTC
+        let epoch_ms = 1710504000000.0;
+        let tz: Tz = "UTC".parse().unwrap();
+
+        let opts = ToLocaleStringOptions {
+            hour12: true,
+            ..Default::default()
+        };
+        let result = format_date_in_timezone(epoch_ms, &tz, &opts);
+        assert_eq!(result, "03/15/2024, 12:00:00 PM");
+    }
+}

--- a/modules/src/intl/mod.rs
+++ b/modules/src/intl/mod.rs
@@ -1,0 +1,228 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Minimal Intl module for LLRT.
+//!
+//! Provides a subset of the `Intl` API focused on timezone support,
+//! enabling compatibility with libraries like dayjs.
+
+mod cldr_data;
+mod date_time_format;
+mod pattern_formatter;
+
+pub use date_time_format::{
+    format_date_in_timezone, get_system_timezone, parse_to_locale_string_options, DateTimeFormat,
+    DateTimeFormatOptions, ToLocaleStringOptions,
+};
+
+use chrono::{TimeZone, Utc};
+use chrono_tz::Tz;
+use cldr_data::get_locale_data;
+use pattern_formatter::{combine_datetime, format_with_pattern};
+use rsquickjs::{
+    function::{Constructor, Opt, This},
+    prelude::Func,
+    Class, Coerced, Ctx, Exception, Object, Result, Value,
+};
+
+/// Initialize the Intl global object with DateTimeFormat
+pub fn init(ctx: &Ctx<'_>) -> Result<()> {
+    let globals = ctx.globals();
+
+    // Create Intl object
+    let intl = Object::new(ctx.clone())?;
+
+    // Add DateTimeFormat constructor
+    Class::<DateTimeFormat>::define(&intl)?;
+
+    // Set Intl global
+    globals.set("Intl", intl)?;
+
+    // Patch Date.prototype.toLocaleString to support timeZone option
+    patch_date_to_locale_string(ctx)?;
+
+    Ok(())
+}
+
+/// Patch Date.prototype.toLocaleString to support the timeZone option
+fn patch_date_to_locale_string(ctx: &Ctx<'_>) -> Result<()> {
+    let globals = ctx.globals();
+    let date_ctor: Constructor = globals.get("Date")?;
+    let date_proto: Object = date_ctor.get("prototype")?;
+
+    // Replace toLocaleString with our implementation
+    date_proto.set("toLocaleString", Func::from(date_to_locale_string))?;
+
+    Ok(())
+}
+
+/// Custom Date.prototype.toLocaleString implementation with timezone and locale support
+fn date_to_locale_string<'js>(
+    ctx: Ctx<'js>,
+    this: This<Value<'js>>,
+    locale: Opt<Value<'js>>,
+    options: Opt<Object<'js>>,
+) -> Result<String> {
+    // Coerce Date to number (uses valueOf internally, same as getTime)
+    let epoch_ms = this
+        .0
+        .get::<Coerced<f64>>()
+        .map(|c| c.0)
+        .map_err(|_| Exception::throw_type(&ctx, "this is not a Date object"))?;
+
+    // Check for NaN (Invalid Date)
+    if epoch_ms.is_nan() {
+        return Ok("Invalid Date".to_string());
+    }
+
+    // Parse locale
+    let locale_str = parse_locale_arg(locale)?;
+    let locale_data = get_locale_data(&locale_str);
+
+    // Parse options
+    let (tz, opts) = parse_to_locale_string_options(&ctx, options.0)?;
+
+    let timezone = tz.unwrap_or_else(|| {
+        get_system_timezone()
+            .parse::<Tz>()
+            .unwrap_or(chrono_tz::UTC)
+    });
+
+    // Convert epoch to DateTime
+    let epoch_secs = (epoch_ms / 1000.0) as i64;
+    let epoch_nanos = ((epoch_ms % 1000.0) * 1_000_000.0) as u32;
+
+    let utc_dt = match Utc.timestamp_opt(epoch_secs, epoch_nanos).single() {
+        Some(dt) => dt,
+        None => return Ok(String::new()),
+    };
+
+    let local_dt = utc_dt.with_timezone(&timezone);
+
+    // Determine hour12 setting - use locale default if not explicitly set
+    let hour12 = if opts.hour12_set {
+        Some(opts.hour12)
+    } else {
+        Some(locale_data.hour12_default)
+    };
+
+    // Format using CLDR patterns based on dateStyle/timeStyle
+    let (date_style, time_style) = (opts.date_style.as_deref(), opts.time_style.as_deref());
+
+    match (date_style, time_style) {
+        (Some(ds), Some(ts)) => {
+            // Both date and time
+            let date_pattern = get_date_pattern(ds, locale_data);
+            let time_pattern = get_time_pattern(ts, locale_data);
+            let date_str = format_with_pattern(&local_dt, date_pattern, locale_data, hour12);
+            let time_str = format_with_pattern(&local_dt, time_pattern, locale_data, hour12);
+            Ok(combine_datetime(
+                &date_str,
+                &time_str,
+                locale_data.datetime_pattern,
+            ))
+        },
+        (Some(ds), None) => {
+            // Date only
+            let date_pattern = get_date_pattern(ds, locale_data);
+            Ok(format_with_pattern(
+                &local_dt,
+                date_pattern,
+                locale_data,
+                hour12,
+            ))
+        },
+        (None, Some(ts)) => {
+            // Time only
+            let time_pattern = get_time_pattern(ts, locale_data);
+            Ok(format_with_pattern(
+                &local_dt,
+                time_pattern,
+                locale_data,
+                hour12,
+            ))
+        },
+        (None, None) => {
+            // Default: short date and medium time (matching browser behavior)
+            let date_str = format_with_pattern(
+                &local_dt,
+                locale_data.date_formats.short,
+                locale_data,
+                hour12,
+            );
+            let time_str = format_with_pattern(
+                &local_dt,
+                locale_data.time_formats.medium,
+                locale_data,
+                hour12,
+            );
+            Ok(combine_datetime(
+                &date_str,
+                &time_str,
+                locale_data.datetime_pattern,
+            ))
+        },
+    }
+}
+
+/// Parse locale argument from JavaScript
+fn parse_locale_arg(locale: Opt<Value<'_>>) -> Result<String> {
+    if let Some(val) = locale.into_inner() {
+        if val.is_undefined() || val.is_null() {
+            return Ok("en-US".to_string());
+        }
+        if let Some(s) = val.as_string() {
+            return s.to_string();
+        }
+        if let Some(arr) = val.as_array() {
+            if let Ok(first) = arr.get::<Value>(0) {
+                if let Some(s) = first.as_string() {
+                    return s.to_string();
+                }
+            }
+        }
+    }
+    Ok("en-US".to_string())
+}
+
+/// Get date pattern for a given style
+fn get_date_pattern<'a>(style: &str, locale_data: &'a cldr_data::LocaleData) -> &'a str {
+    match style {
+        "full" => locale_data.date_formats.full,
+        "long" => locale_data.date_formats.long,
+        "medium" => locale_data.date_formats.medium,
+        "short" => locale_data.date_formats.short,
+        _ => locale_data.date_formats.medium,
+    }
+}
+
+/// Get time pattern for a given style
+fn get_time_pattern<'a>(style: &str, locale_data: &'a cldr_data::LocaleData) -> &'a str {
+    match style {
+        "full" => locale_data.time_formats.full,
+        "long" => locale_data.time_formats.long,
+        "medium" => locale_data.time_formats.medium,
+        "short" => locale_data.time_formats.short,
+        _ => locale_data.time_formats.medium,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_system_timezone() {
+        let tz = get_system_timezone();
+        assert!(!tz.is_empty());
+        // Should be a valid IANA timezone
+        assert!(tz.parse::<Tz>().is_ok());
+    }
+
+    #[test]
+    fn test_system_timezone_parseable() {
+        let tz_str = get_system_timezone();
+        let tz: Tz = tz_str.parse().expect("System timezone should be valid");
+        assert!(!tz.name().is_empty());
+    }
+}

--- a/modules/src/intl/pattern_formatter.rs
+++ b/modules/src/intl/pattern_formatter.rs
@@ -1,0 +1,480 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! CLDR pattern parser and formatter.
+//!
+//! Parses Unicode CLDR date/time patterns and formats dates accordingly.
+//! Pattern syntax follows Unicode Technical Standard #35:
+//! https://unicode.org/reports/tr35/tr35-dates.html#Date_Field_Symbol_Table
+
+use crate::intl::cldr_data::LocaleData;
+use chrono::{DateTime, Datelike, Offset, Timelike};
+use chrono_tz::Tz;
+
+/// Format a DateTime using a CLDR pattern string
+pub fn format_with_pattern(
+    dt: &DateTime<Tz>,
+    pattern: &str,
+    locale_data: &LocaleData,
+    hour12_override: Option<bool>,
+) -> String {
+    let mut result = String::with_capacity(pattern.len() * 2);
+    let mut chars = pattern.chars().peekable();
+
+    while let Some(ch) = chars.next() {
+        match ch {
+            // Quoted literal text
+            '\'' => {
+                // Check for escaped quote ('')
+                if chars.peek() == Some(&'\'') {
+                    chars.next();
+                    result.push('\'');
+                } else {
+                    // Collect until closing quote
+                    for c in chars.by_ref() {
+                        if c == '\'' {
+                            break;
+                        }
+                        result.push(c);
+                    }
+                }
+            },
+            // Pattern letters
+            'y' | 'Y' => {
+                let count = 1 + consume_same(&mut chars, ch);
+                format_year(&mut result, dt.year(), count);
+            },
+            'M' | 'L' => {
+                let count = 1 + consume_same(&mut chars, ch);
+                format_month(&mut result, dt.month() as usize, count, locale_data);
+            },
+            'd' => {
+                let count = 1 + consume_same(&mut chars, ch);
+                format_day(&mut result, dt.day(), count);
+            },
+            'E' | 'e' | 'c' => {
+                let count = 1 + consume_same(&mut chars, ch);
+                format_weekday(
+                    &mut result,
+                    dt.weekday().num_days_from_sunday() as usize,
+                    count,
+                    locale_data,
+                );
+            },
+            'a' => {
+                consume_same(&mut chars, ch);
+                // Only show AM/PM if we're using 12-hour format
+                let use_12h = hour12_override.unwrap_or(true);
+                if use_12h {
+                    let hour = dt.hour();
+                    if hour < 12 {
+                        result.push_str(locale_data.am);
+                    } else {
+                        result.push_str(locale_data.pm);
+                    }
+                }
+            },
+            'h' => {
+                let count = 1 + consume_same(&mut chars, ch);
+                let hour = dt.hour();
+                // If hour12 is explicitly false, use 24-hour format instead
+                let use_12h = hour12_override.unwrap_or(true);
+                if use_12h {
+                    // 12-hour format (1-12)
+                    let hour12 = match hour {
+                        0 => 12,
+                        1..=12 => hour,
+                        _ => hour - 12,
+                    };
+                    format_number(&mut result, hour12, count);
+                } else {
+                    // 24-hour format (0-23)
+                    format_number(&mut result, hour, count);
+                }
+            },
+            'H' => {
+                let count = 1 + consume_same(&mut chars, ch);
+                let hour = dt.hour();
+                // If hour12 is explicitly true, use 12-hour format instead
+                let use_12h = hour12_override.unwrap_or(false);
+                if use_12h {
+                    let hour12 = match hour {
+                        0 => 12,
+                        1..=12 => hour,
+                        _ => hour - 12,
+                    };
+                    format_number(&mut result, hour12, count);
+                } else {
+                    // 24-hour format (0-23)
+                    format_number(&mut result, hour, count);
+                }
+            },
+            'm' => {
+                let count = 1 + consume_same(&mut chars, ch);
+                format_number(&mut result, dt.minute(), count);
+            },
+            's' => {
+                let count = 1 + consume_same(&mut chars, ch);
+                format_number(&mut result, dt.second(), count);
+            },
+            'z' => {
+                let count = 1 + consume_same(&mut chars, ch);
+                format_timezone(&mut result, dt, count);
+            },
+            'Z' | 'O' | 'v' | 'V' | 'X' | 'x' => {
+                let count = 1 + consume_same(&mut chars, ch);
+                format_timezone(&mut result, dt, count);
+            },
+            // Skip these pattern letters (not commonly needed)
+            'G' | 'q' | 'Q' | 'w' | 'W' | 'D' | 'F' | 'g' | 'A' | 'S' => {
+                consume_same(&mut chars, ch);
+            },
+            // Pass through literal characters
+            _ => {
+                result.push(ch);
+            },
+        }
+    }
+
+    // If hour12=true and pattern originally used 24h format (H) without AM/PM marker,
+    // we need to append AM/PM since we converted to 12h format
+    if let Some(true) = hour12_override {
+        if !pattern.contains('a') && pattern.contains('H') {
+            result.push(' ');
+            if dt.hour() < 12 {
+                result.push_str(locale_data.am);
+            } else {
+                result.push_str(locale_data.pm);
+            }
+        }
+    }
+
+    result
+}
+
+/// Consume consecutive identical characters, returning count of additional chars
+fn consume_same(chars: &mut std::iter::Peekable<std::str::Chars>, ch: char) -> usize {
+    let mut count = 0;
+    while chars.peek() == Some(&ch) {
+        chars.next();
+        count += 1;
+    }
+    count
+}
+
+/// Format year based on pattern width
+fn format_year(result: &mut String, year: i32, width: usize) {
+    let mut buf = itoa::Buffer::new();
+    if width == 2 {
+        // 2-digit year
+        let short_year = (year % 100).unsigned_abs();
+        if short_year < 10 {
+            result.push('0');
+        }
+        result.push_str(buf.format(short_year));
+    } else {
+        result.push_str(buf.format(year));
+    }
+}
+
+/// Format month based on pattern width
+fn format_month(result: &mut String, month: usize, width: usize, locale_data: &LocaleData) {
+    match width {
+        1 => {
+            // Numeric, no padding
+            let mut buf = itoa::Buffer::new();
+            result.push_str(buf.format(month));
+        },
+        2 => {
+            // Numeric, zero-padded
+            let mut buf = itoa::Buffer::new();
+            if month < 10 {
+                result.push('0');
+            }
+            result.push_str(buf.format(month));
+        },
+        3 => {
+            // Abbreviated
+            if (1..=12).contains(&month) {
+                result.push_str(locale_data.months_abbr[month - 1]);
+            }
+        },
+        _ => {
+            // Wide (4+)
+            if (1..=12).contains(&month) {
+                result.push_str(locale_data.months_wide[month - 1]);
+            }
+        },
+    }
+}
+
+/// Format day based on pattern width
+fn format_day(result: &mut String, day: u32, width: usize) {
+    format_number(result, day, width);
+}
+
+/// Format weekday based on pattern width
+fn format_weekday(result: &mut String, weekday: usize, width: usize, locale_data: &LocaleData) {
+    match width {
+        1..=3 => {
+            // Abbreviated
+            result.push_str(locale_data.days_abbr[weekday]);
+        },
+        _ => {
+            // Wide (4+)
+            result.push_str(locale_data.days_wide[weekday]);
+        },
+    }
+}
+
+/// Format a number with optional zero-padding
+fn format_number(result: &mut String, value: u32, min_width: usize) {
+    let mut buf = itoa::Buffer::new();
+    let s = buf.format(value);
+    if min_width >= 2 && s.len() < min_width {
+        for _ in 0..(min_width - s.len()) {
+            result.push('0');
+        }
+    }
+    result.push_str(s);
+}
+
+/// Format timezone
+fn format_timezone(result: &mut String, dt: &DateTime<Tz>, width: usize) {
+    let offset = dt.offset().fix();
+    let total_secs = offset.local_minus_utc();
+    let hours = total_secs / 3600;
+    let mins = (total_secs % 3600).abs() / 60;
+
+    if width >= 4 {
+        // Long form: timezone name
+        result.push_str(dt.timezone().name());
+    } else {
+        // Short form: GMT offset
+        result.push_str("GMT");
+        if hours >= 0 {
+            result.push('+');
+        }
+        let mut buf = itoa::Buffer::new();
+        result.push_str(buf.format(hours));
+        if mins != 0 {
+            result.push(':');
+            if mins < 10 {
+                result.push('0');
+            }
+            result.push_str(buf.format(mins));
+        }
+    }
+}
+
+/// Combine date and time strings using a datetime pattern
+pub fn combine_datetime(date: &str, time: &str, pattern: &str) -> String {
+    pattern.replace("{1}", date).replace("{0}", time)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::intl::cldr_data::get_locale_data;
+    use chrono::{TimeZone, Utc};
+
+    fn make_dt(year: i32, month: u32, day: u32, hour: u32, min: u32, sec: u32) -> DateTime<Tz> {
+        let tz: Tz = "UTC".parse().unwrap();
+        Utc.with_ymd_and_hms(year, month, day, hour, min, sec)
+            .unwrap()
+            .with_timezone(&tz)
+    }
+
+    #[test]
+    fn test_format_year() {
+        let dt = make_dt(2024, 3, 15, 10, 30, 45);
+        let locale = get_locale_data("en-US");
+
+        assert!(format_with_pattern(&dt, "y", locale, None).contains("2024"));
+        assert!(format_with_pattern(&dt, "yy", locale, None).contains("24"));
+        assert!(format_with_pattern(&dt, "yyyy", locale, None).contains("2024"));
+    }
+
+    #[test]
+    fn test_format_month() {
+        let dt = make_dt(2024, 3, 15, 10, 30, 45);
+        let locale = get_locale_data("en-US");
+
+        assert_eq!(format_with_pattern(&dt, "M", locale, None), "3");
+        assert_eq!(format_with_pattern(&dt, "MM", locale, None), "03");
+        assert_eq!(format_with_pattern(&dt, "MMM", locale, None), "Mar");
+        assert_eq!(format_with_pattern(&dt, "MMMM", locale, None), "March");
+    }
+
+    #[test]
+    fn test_format_day() {
+        let dt = make_dt(2024, 3, 5, 10, 30, 45);
+        let locale = get_locale_data("en-US");
+
+        assert_eq!(format_with_pattern(&dt, "d", locale, None), "5");
+        assert_eq!(format_with_pattern(&dt, "dd", locale, None), "05");
+    }
+
+    #[test]
+    fn test_format_weekday() {
+        // March 15, 2024 is a Friday
+        let dt = make_dt(2024, 3, 15, 10, 30, 45);
+        let locale = get_locale_data("en-US");
+
+        assert_eq!(format_with_pattern(&dt, "E", locale, None), "Fri");
+        assert_eq!(format_with_pattern(&dt, "EEEE", locale, None), "Friday");
+    }
+
+    #[test]
+    fn test_format_hour_12() {
+        let dt = make_dt(2024, 3, 15, 14, 30, 45);
+        let locale = get_locale_data("en-US");
+
+        assert_eq!(format_with_pattern(&dt, "h", locale, None), "2");
+        assert_eq!(format_with_pattern(&dt, "hh", locale, None), "02");
+    }
+
+    #[test]
+    fn test_format_hour_24() {
+        let dt = make_dt(2024, 3, 15, 14, 30, 45);
+        let locale = get_locale_data("en-US");
+
+        assert_eq!(format_with_pattern(&dt, "H", locale, None), "14");
+        assert_eq!(format_with_pattern(&dt, "HH", locale, None), "14");
+    }
+
+    #[test]
+    fn test_format_minute_second() {
+        let dt = make_dt(2024, 3, 15, 14, 5, 9);
+        let locale = get_locale_data("en-US");
+
+        assert_eq!(format_with_pattern(&dt, "m", locale, None), "5");
+        assert_eq!(format_with_pattern(&dt, "mm", locale, None), "05");
+        assert_eq!(format_with_pattern(&dt, "s", locale, None), "9");
+        assert_eq!(format_with_pattern(&dt, "ss", locale, None), "09");
+    }
+
+    #[test]
+    fn test_format_am_pm() {
+        let locale = get_locale_data("en-US");
+
+        let dt_am = make_dt(2024, 3, 15, 10, 30, 45);
+        assert_eq!(format_with_pattern(&dt_am, "a", locale, None), "AM");
+
+        let dt_pm = make_dt(2024, 3, 15, 14, 30, 45);
+        assert_eq!(format_with_pattern(&dt_pm, "a", locale, None), "PM");
+    }
+
+    #[test]
+    fn test_format_quoted_literal() {
+        let dt = make_dt(2024, 3, 15, 10, 30, 45);
+        let locale = get_locale_data("en-US");
+
+        assert_eq!(
+            format_with_pattern(&dt, "d 'de' MMMM", locale, None),
+            "15 de March"
+        );
+    }
+
+    #[test]
+    fn test_format_full_date_en_us() {
+        let dt = make_dt(2024, 3, 15, 14, 30, 45);
+        let locale = get_locale_data("en-US");
+
+        let result = format_with_pattern(&dt, locale.date_formats.full, locale, None);
+        assert_eq!(result, "Friday, March 15, 2024");
+    }
+
+    #[test]
+    fn test_format_full_date_de() {
+        let dt = make_dt(2024, 3, 15, 14, 30, 45);
+        let locale = get_locale_data("de-DE");
+
+        let result = format_with_pattern(&dt, locale.date_formats.full, locale, None);
+        assert_eq!(result, "Freitag, 15. März 2024");
+    }
+
+    #[test]
+    fn test_format_short_date_en_us() {
+        let dt = make_dt(2024, 3, 15, 14, 30, 45);
+        let locale = get_locale_data("en-US");
+
+        let result = format_with_pattern(&dt, locale.date_formats.short, locale, None);
+        assert_eq!(result, "3/15/24");
+    }
+
+    #[test]
+    fn test_format_short_date_de() {
+        let dt = make_dt(2024, 3, 15, 14, 30, 45);
+        let locale = get_locale_data("de-DE");
+
+        let result = format_with_pattern(&dt, locale.date_formats.short, locale, None);
+        assert_eq!(result, "15.03.24");
+    }
+
+    #[test]
+    fn test_format_short_time_en_us() {
+        let dt = make_dt(2024, 3, 15, 14, 30, 45);
+        let locale = get_locale_data("en-US");
+
+        let result = format_with_pattern(&dt, locale.time_formats.short, locale, None);
+        assert_eq!(result, "2:30 PM");
+    }
+
+    #[test]
+    fn test_format_short_time_de() {
+        let dt = make_dt(2024, 3, 15, 14, 30, 45);
+        let locale = get_locale_data("de-DE");
+
+        let result = format_with_pattern(&dt, locale.time_formats.short, locale, None);
+        assert_eq!(result, "14:30");
+    }
+
+    #[test]
+    fn test_combine_datetime() {
+        assert_eq!(
+            combine_datetime("3/15/24", "2:30 PM", "{1}, {0}"),
+            "3/15/24, 2:30 PM"
+        );
+        assert_eq!(
+            combine_datetime("15.03.24", "14:30", "{1} {0}"),
+            "15.03.24 14:30"
+        );
+    }
+
+    #[test]
+    fn test_midnight_12h() {
+        let dt = make_dt(2024, 3, 15, 0, 0, 0);
+        let locale = get_locale_data("en-US");
+
+        let result = format_with_pattern(&dt, "h:mm a", locale, None);
+        assert_eq!(result, "12:00 AM");
+    }
+
+    #[test]
+    fn test_noon_12h() {
+        let dt = make_dt(2024, 3, 15, 12, 0, 0);
+        let locale = get_locale_data("en-US");
+
+        let result = format_with_pattern(&dt, "h:mm a", locale, None);
+        assert_eq!(result, "12:00 PM");
+    }
+
+    #[test]
+    fn test_japanese_locale() {
+        let dt = make_dt(2024, 3, 15, 14, 30, 45);
+        let locale = get_locale_data("ja-JP");
+
+        let result = format_with_pattern(&dt, locale.date_formats.long, locale, None);
+        assert_eq!(result, "2024年3月15日");
+    }
+
+    #[test]
+    fn test_korean_locale() {
+        let dt = make_dt(2024, 3, 15, 14, 30, 45);
+        let locale = get_locale_data("ko-KR");
+
+        let result = format_with_pattern(&dt, locale.date_formats.medium, locale, None);
+        assert_eq!(result, "2024. 3. 15.");
+    }
+}

--- a/modules/src/lib.rs
+++ b/modules/src/lib.rs
@@ -36,6 +36,9 @@ pub mod fetch;
 #[cfg(feature = "url")]
 pub mod url;
 
+#[cfg(feature = "intl")]
+pub mod intl;
+
 pub mod async_hooks;
 pub mod hooking;
 pub mod module;
@@ -81,6 +84,10 @@ pub fn init(
     #[cfg(feature = "fetch")]
     {
         fetch::init(ctx)?;
+    }
+    #[cfg(feature = "intl")]
+    {
+        intl::init(ctx)?;
     }
     Ok(())
 }

--- a/rsquickjs/core/src/context/ctx.rs
+++ b/rsquickjs/core/src/context/ctx.rs
@@ -494,7 +494,7 @@ impl<'js> Ctx<'js> {
         let stack_level = std::ffi::c_int::try_from(stack_level).unwrap();
         let atom = unsafe { qjs::JS_GetScriptOrModuleName(self.as_ptr(), stack_level) };
         #[allow(clippy::useless_conversion)] //needed for multi platform binding support
-        if qjs::__JS_ATOM_NULL == TryInto::<i32>::try_into(atom).unwrap() {
+        if qjs::__JS_ATOM_NULL == TryInto::<u32>::try_into(atom).unwrap() {
             unsafe { qjs::JS_FreeAtom(self.as_ptr(), atom) };
             return None;
         }


### PR DESCRIPTION
- Added `intl` module providing a subset of the Intl API focused on timezone support.
- Implemented `DateTimeFormat` class with methods for formatting dates in specified timezones.
- Patched `Date.prototype.toLocaleString` to support `timeZone` option.
- Introduced CLDR pattern parser and formatter for date/time formatting.
- Added comprehensive tests for various date and time formatting scenarios across different locales.

### Issue # (if available)

<!--  **Please post the link to the resolved issue** -->

### Description of changes

<!-- **Please explain what your changes does** -->

### Checklist

- [ ] Added change to the changelog
- [ ] Created unit tests for my feature if needed
